### PR TITLE
Port changes made to to extracted files during the Swift 3 migration

### DIFF
--- a/WireRequestStrategy/ZMContextChangeTracker.h
+++ b/WireRequestStrategy/ZMContextChangeTracker.h
@@ -1,36 +1,36 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
-@import  Foundation;
 
 @class NSFetchRequest;
+
 
 NS_ASSUME_NONNULL_BEGIN
 @protocol ZMContextChangeTracker <NSObject>
 
-- (void)objectsDidChange:(NSSet *)object;
+- (void)objectsDidChange:(NSSet<NSManagedObject *> *)object;
 
 /// Returns the fetch request to retrieve the initial set of objects.
 ///
 /// During app launch this fetch request is executed and the resulting objects are passed to -addTrackedObjects:
 - (nullable NSFetchRequest *)fetchRequestForTrackedObjects;
 /// Adds tracked objects -- which have been retrieved by using the fetch request returned by -fetchRequestForTrackedObjects
-- (void)addTrackedObjects:(NSSet *)objects;
+- (void)addTrackedObjects:(NSSet<NSManagedObject *> *)objects;
 
 @end
 

--- a/WireRequestStrategy/ZMLocallyModifiedObjectSet.h
+++ b/WireRequestStrategy/ZMLocallyModifiedObjectSet.h
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 
 @import Foundation;
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ZMLocallyModifiedObjectSet : NSObject <ZMOutstandingItems>
 
-@property (nonatomic, readonly) NSSet *trackedKeys;
+@property (nonatomic, readonly, nullable) NSSet *trackedKeys;
 
 // Init with all keys tracked
 - (instancetype)init;

--- a/WireRequestStrategy/ZMUpstreamRequest.h
+++ b/WireRequestStrategy/ZMUpstreamRequest.h
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 
 @import ZMTransport;
@@ -23,12 +23,12 @@
 @interface ZMUpstreamRequest : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithKeys:(NSSet *)keys transportRequest:(ZMTransportRequest *)transportRequest;
-- (instancetype)initWithKeys:(NSSet *)keys transportRequest:(ZMTransportRequest *)transportRequest userInfo:(NSDictionary *)info NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithKeys:(NSSet<NSString *> *)keys transportRequest:(ZMTransportRequest *)transportRequest;
+- (instancetype)initWithKeys:(NSSet<NSString *> *)keys transportRequest:(ZMTransportRequest *)transportRequest userInfo:(NSDictionary *)info NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithTransportRequest:(ZMTransportRequest *)transportRequest;
 
 
-@property (nonatomic, readonly) NSSet *keys;
+@property (nonatomic, readonly) NSSet<NSString *> *keys;
 @property (nonatomic, readonly) ZMTransportRequest *transportRequest;
 @property (nonatomic) ZMTransportResponse *transportResponse;
 @property (nonatomic, readonly) NSDictionary *userInfo;

--- a/WireRequestStrategy/ZMUpstreamTranscoder.h
+++ b/WireRequestStrategy/ZMUpstreamTranscoder.h
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 
 @class ZMUpstreamRequest;
@@ -24,8 +24,8 @@
 
 - (BOOL)shouldProcessUpdatesBeforeInserts;
 
-- (ZMUpstreamRequest  * _Nullable )requestForUpdatingObject:(ZMManagedObject  * _Nonnull )managedObject forKeys:(NSSet  * _Nonnull )keys;
-- (ZMUpstreamRequest  * _Nullable )requestForInsertingObject:(ZMManagedObject  * _Nonnull )managedObject forKeys:(NSSet  * _Nullable )keys;
+- (ZMUpstreamRequest  * _Nullable )requestForUpdatingObject:(ZMManagedObject  * _Nonnull )managedObject forKeys:(NSSet<NSString *>  * _Nonnull )keys;
+- (ZMUpstreamRequest  * _Nullable )requestForInsertingObject:(ZMManagedObject  * _Nonnull )managedObject forKeys:(NSSet<NSString *>  * _Nullable )keys;
 
 - (void)updateInsertedObject:(ZMManagedObject * _Nonnull)managedObject request:(ZMUpstreamRequest * _Nonnull)upstreamRequest response:(ZMTransportResponse * _Nonnull)response;
 
@@ -33,7 +33,7 @@
 - (BOOL)updateUpdatedObject:(ZMManagedObject * _Nonnull)managedObject
             requestUserInfo:(NSDictionary * _Nullable)requestUserInfo
                    response:(ZMTransportResponse * _Nonnull)response
-                keysToParse:(NSSet * _Nonnull)keysToParse;
+                keysToParse:(NSSet<NSString *> * _Nonnull)keysToParse;
 
 // Should return the objects that need to be refetched from the BE in case of upload error
 - (ZMManagedObject * _Nullable)objectToRefetchForFailedUpdateOfObject:(ZMManagedObject * _Nonnull)managedObject;
@@ -52,7 +52,7 @@
 
 /// If implemented, the upstream object sync will call this when an upstream request timed out. Having a request
 /// that might time out but not implementing this will trigger an assertion.
-- (void)requestExpiredForObject:(ZMManagedObject * _Nonnull)managedObject forKeys:(NSSet * _Nonnull)keys;
+- (void)requestExpiredForObject:(ZMManagedObject * _Nonnull)managedObject forKeys:(NSSet<NSString *> * _Nonnull)keys;
 
 /// If implemented, the transcoder can refuse requests until a conditions is fullfilled
 /// Object will be not removed from objects to be synced
@@ -62,11 +62,11 @@
 /// If this method reutrns TRUE the object will be added back to sync queue.
 /// If it returns FALSE, it will be deleted (if it's an insertion) or the keys will be reset (if it's an update)
 - (BOOL)shouldRetryToSyncAfterFailedToUpdateObject:(ZMManagedObject * _Nonnull)managedObject
-                             request:(ZMUpstreamRequest * _Nonnull)upstreamRequest
-                            response:(ZMTransportResponse * _Nonnull)response
-                         keysToParse:(NSSet * _Nonnull)keys;
+                                           request:(ZMUpstreamRequest * _Nonnull)upstreamRequest
+                                          response:(ZMTransportResponse * _Nonnull)response
+                                       keysToParse:(NSSet<NSString *> * _Nonnull)keys;
 
 @end
 
 /// Asserts with a description of how it failed to generate a request from a transcoder
-void ZMTrapUnableToGenerateRequest(NSSet * _Nonnull keys, id _Nonnull transcoder);
+void ZMTrapUnableToGenerateRequest(NSSet<NSString *> * _Nonnull keys, id _Nonnull transcoder);


### PR DESCRIPTION
During the Swift 3 migration of the sync-engine some files were modified, which have previously been extracted to this framework. This PR re-applies these changes.