### PR TITLE
Move missing test classes from sync-engine

### DIFF
--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		1621D2741D7715EA007108C2 /* ZMObjectSyncStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1621D2721D7715EA007108C2 /* ZMObjectSyncStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1621D2751D7715EA007108C2 /* ZMObjectSyncStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1621D2731D7715EA007108C2 /* ZMObjectSyncStrategy.m */; };
 		1621D2811D783529007108C2 /* RequestAvailableNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1621D2801D783529007108C2 /* RequestAvailableNotificationTests.swift */; };
+		1666AA2C1D93FA0B00164C06 /* ZMChangeTrackerBootstrapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1666AA2B1D93FA0B00164C06 /* ZMChangeTrackerBootstrapTests.m */; };
+		1666AA2E1D93FBE200164C06 /* ZMSyncOperationSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1666AA2D1D93FBE200164C06 /* ZMSyncOperationSetTests.m */; };
 		1669016E1D707509000FE4AF /* WireRequestStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1669016D1D707509000FE4AF /* WireRequestStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		166901CF1D7081C7000FE4AF /* RequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166901A71D7081C7000FE4AF /* RequestStrategy.swift */; };
 		166901D01D7081C7000FE4AF /* ZMContextChangeTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 166901A81D7081C7000FE4AF /* ZMContextChangeTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -161,6 +163,8 @@
 		1621D2721D7715EA007108C2 /* ZMObjectSyncStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMObjectSyncStrategy.h; sourceTree = "<group>"; };
 		1621D2731D7715EA007108C2 /* ZMObjectSyncStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMObjectSyncStrategy.m; sourceTree = "<group>"; };
 		1621D2801D783529007108C2 /* RequestAvailableNotificationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestAvailableNotificationTests.swift; sourceTree = "<group>"; };
+		1666AA2B1D93FA0B00164C06 /* ZMChangeTrackerBootstrapTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMChangeTrackerBootstrapTests.m; sourceTree = "<group>"; };
+		1666AA2D1D93FBE200164C06 /* ZMSyncOperationSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMSyncOperationSetTests.m; sourceTree = "<group>"; };
 		1669016A1D707509000FE4AF /* WireRequestStrategy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireRequestStrategy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1669016D1D707509000FE4AF /* WireRequestStrategy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WireRequestStrategy.h; sourceTree = "<group>"; };
 		1669016F1D707509000FE4AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -382,6 +386,8 @@
 			children = (
 				1621D2211D75AB2D007108C2 /* MockDataModel */,
 				1669017B1D707509000FE4AF /* Info.plist */,
+				1666AA2B1D93FA0B00164C06 /* ZMChangeTrackerBootstrapTests.m */,
+				1666AA2D1D93FBE200164C06 /* ZMSyncOperationSetTests.m */,
 				166902161D709110000FE4AF /* ZMDependentObjectsTests.m */,
 				166902171D709110000FE4AF /* ZMDownstreamObjectSyncOrderingTests.m */,
 				166902181D709110000FE4AF /* ZMDownstreamObjectSyncTests.m */,
@@ -641,6 +647,7 @@
 			files = (
 				1621D2601D75C73E007108C2 /* ZMDownstreamObjectSyncOrderingTests.m in Sources */,
 				1621D2811D783529007108C2 /* RequestAvailableNotificationTests.swift in Sources */,
+				1666AA2E1D93FBE200164C06 /* ZMSyncOperationSetTests.m in Sources */,
 				1621D2621D75C745007108C2 /* ZMDownstreamObjectSyncWithWhitelistingTests.m in Sources */,
 				1621D2291D75AB2D007108C2 /* MockEntity2.m in Sources */,
 				1621D2631D75C749007108C2 /* ZMImagePreprocessingTrackerTests.m in Sources */,
@@ -655,6 +662,7 @@
 				1621D2681D75C77B007108C2 /* ZMRequestGeneratorTests.m in Sources */,
 				1621D22A1D75AB2D007108C2 /* MockModelObjectContextFactory.m in Sources */,
 				1621D2651D75C750007108C2 /* ZMLocallyModifiedObjectSetTests.m in Sources */,
+				1666AA2C1D93FA0B00164C06 /* ZMChangeTrackerBootstrapTests.m in Sources */,
 				1621D26D1D75C806007108C2 /* NSManagedObjectContext+TestHelpers.m in Sources */,
 				1621D2671D75C776007108C2 /* ZMRemoteIdentifierObjectSyncTests.m in Sources */,
 				1621D26A1D75C782007108C2 /* ZMTimedSingleRequestSyncTests.m in Sources */,

--- a/WireRequestStrategyTests/ZMChangeTrackerBootstrapTests.m
+++ b/WireRequestStrategyTests/ZMChangeTrackerBootstrapTests.m
@@ -1,0 +1,370 @@
+// 
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+// 
+
+@import ZMCDataModel;
+@import ZMTesting;
+
+#import "ZMContextChangeTracker.h"
+#import "ZMChangeTrackerBootstrap.h"
+#import "ZMChangeTrackerBootstrap+Testing.h"
+
+@interface FakeChangeTracker : NSObject <ZMContextChangeTracker>
+@property (nonatomic) NSFetchRequest *fetchRequest;
+@property (nonatomic) NSSet *objectsToUpdate;
+@end
+
+@implementation FakeChangeTracker
+
+- (void)objectsDidChange:(NSSet *)objects
+{
+    (void)objects;
+}
+
+- (NSFetchRequest *)fetchRequestForTrackedObjects
+{
+    return self.fetchRequest;
+}
+
+- (void)addTrackedObjects:(NSSet *)objects
+{
+    self.objectsToUpdate = objects;
+}
+
+@end
+
+
+
+@interface ZMChangeTrackerBootstrapTests : ZMTBaseTest
+
+@property (nonatomic) ZMChangeTrackerBootstrap *sut;
+@property (nonatomic) ZMTestSession *testSession;
+@property (nonatomic) ZMUser *user1;
+@property (nonatomic) ZMUser *user2;
+@property (nonatomic) ZMUser *selfUser;
+@property (nonatomic) ZMConversation *conversation1;
+@property (nonatomic) ZMConversation *conversation2;
+@property (nonatomic) ZMConnection *connection1;
+
+@property (nonatomic) FakeChangeTracker *changeTracker1;
+@property (nonatomic) FakeChangeTracker *changeTracker2;
+
+@end
+
+
+
+@implementation ZMChangeTrackerBootstrapTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    self.testSession = [[ZMTestSession alloc] initWithDispatchGroup:self.dispatchGroup];
+    [self.testSession prepareForTestNamed:self.name];
+    
+    self.user1 = [ZMUser insertNewObjectInManagedObjectContext:self.testSession.uiMOC];
+    self.user1.name = @"Hans";
+    self.user2 = [ZMUser insertNewObjectInManagedObjectContext:self.testSession.uiMOC];
+    self.user2.name = @"Gretel";
+    self.selfUser = [ZMUser selfUserInContext:self.testSession.uiMOC];
+    self.conversation1 = [ZMConversation insertNewObjectInManagedObjectContext:self.testSession.uiMOC];
+    self.conversation1.userDefinedName = @"A Walk in the Forest";
+    self.conversation2 = [ZMConversation insertNewObjectInManagedObjectContext:self.testSession.uiMOC];
+    self.conversation2.userDefinedName = @"The Great Escape";
+    self.connection1 = [ZMConnection insertNewObjectInManagedObjectContext:self.testSession.uiMOC];
+    self.connection1.status = ZMConnectionStatusAccepted;
+    self.user1.connection = self.connection1;
+    self.connection1.conversation = self.conversation1;
+    self.changeTracker1 = [[FakeChangeTracker alloc] init];
+    self.changeTracker2 = [[FakeChangeTracker alloc] init];
+    XCTAssert([self.testSession.uiMOC saveOrRollback]);
+    
+    self.sut = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.testSession.uiMOC changeTrackers:@[self.changeTracker1, self.changeTracker2]];
+}
+
+- (void)tearDown {
+    self.sut = nil;
+    self.user1 = nil;
+    self.user2 = nil;
+    self.conversation1 = nil;
+    self.conversation2 = nil;
+    self.changeTracker1 = nil;
+    self.changeTracker2 = nil;
+    [self.testSession tearDown];
+    [super tearDown];
+}
+
+- (void)testThatItDoesNotReturnAnythingIfThePredicateDoesNotMatch
+{
+    // given
+    self.sut = nil;
+    
+    NSString *entityName = ZMUser.entityName;
+    NSPredicate *predicate1 = [NSPredicate predicateWithFormat:@"name == %@", @"Unknown UserName"];
+    
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request1.predicate = predicate1;
+    
+    self.changeTracker1.fetchRequest = request1;
+    
+    self.sut = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.testSession.uiMOC changeTrackers:@[self.changeTracker1]];
+    
+    // when
+    [self.sut fetchObjectsForChangeTrackers];
+    
+    // then
+    XCTAssertNil(self.changeTracker1.objectsToUpdate);
+}
+
+- (void)testThatItSortsFetchRequestByEntity
+{
+    // given
+    self.sut = nil;
+    
+    NSString *entityName1 = ZMUser.entityName;
+    NSString *entityName2 = ZMConversation.entityName;
+
+    NSPredicate *predicate1 = [NSPredicate predicateWithFormat:@"name != nil"];
+    NSPredicate *predicate2 = [NSPredicate predicateWithFormat:@"userDefinedName != nil"];
+    
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:entityName1];
+    request1.predicate = predicate1;
+    
+    NSFetchRequest *request2 = [NSFetchRequest fetchRequestWithEntityName:entityName2];
+    request2.predicate = predicate2;
+    
+    self.changeTracker1.fetchRequest = request1;
+    self.changeTracker2.fetchRequest = request2;
+    
+    self.sut = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.testSession.uiMOC changeTrackers:@[self.changeTracker1, self.changeTracker2]];
+    
+    // when
+    [self.sut fetchObjectsForChangeTrackers];
+    
+    // then
+    NSSet *expectedSet1 = [NSSet setWithObjects:self.user1, self.user2, nil];
+    NSSet *expectedSet2 = [NSSet setWithObjects:self.conversation1, self.conversation2, nil];
+    XCTAssertEqualObjects(self.changeTracker1.objectsToUpdate, expectedSet1);
+    XCTAssertEqualObjects(self.changeTracker2.objectsToUpdate, expectedSet2);
+}
+
+- (void)testThatItOnlyForwardsObjectsWithMatchingPredicateToTheChangeTrackers
+{
+    // given
+    self.sut = nil;
+    
+    NSString *entityName = ZMUser.entityName;
+    NSPredicate *predicate1 = [NSPredicate predicateWithFormat:@"name == %@", self.user1.name];
+    NSPredicate *predicate2 = [NSPredicate predicateWithFormat:@"name != nil"];
+    
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request1.predicate = predicate1;
+    
+    NSFetchRequest *request2 = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request2.predicate = predicate2;
+    
+    self.changeTracker1.fetchRequest = request1;
+    self.changeTracker2.fetchRequest = request2;
+    
+    self.sut = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.testSession.uiMOC changeTrackers:@[self.changeTracker1, self.changeTracker2]];
+    
+    // when
+    [self.sut fetchObjectsForChangeTrackers];
+    
+    // then
+    NSSet *expectedSet1 = [NSSet setWithObject:self.user1];
+    NSSet *expectedSet2 = [NSSet setWithObjects:self.user1, self.user2, nil];
+    XCTAssertEqualObjects(self.changeTracker1.objectsToUpdate, expectedSet1);
+    XCTAssertEqualObjects(self.changeTracker2.objectsToUpdate, expectedSet2);
+}
+
+- (void)testThatItResolvesPredicatesThroughRelationships;
+{
+    // given
+    self.sut = nil;
+    
+    NSString *entityName = ZMConversation.entityName;
+    NSPredicate *predicate1 = [NSPredicate predicateWithFormat:@"userDefinedName == %@", self.conversation1.userDefinedName];
+    NSPredicate *predicate2 = [NSPredicate predicateWithFormat:@"connection != 0 && connection.status == %@", @(self.connection1.status)];
+    
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request1.predicate = predicate1;
+    
+    NSFetchRequest *request2 = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request2.predicate = predicate2;
+    
+    self.changeTracker1.fetchRequest = request1;
+    self.changeTracker2.fetchRequest = request2;
+    
+    self.sut = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.testSession.uiMOC changeTrackers:@[self.changeTracker1, self.changeTracker2]];
+    
+    // when
+    [self.sut fetchObjectsForChangeTrackers];
+    
+    // then
+    NSSet *expectedSet = [NSSet setWithObject:self.conversation1];
+    XCTAssertEqualObjects(self.changeTracker1.objectsToUpdate, expectedSet);
+    XCTAssertEqualObjects(self.changeTracker2.objectsToUpdate, expectedSet);
+}
+
+
+- (void)testThatItDoesNotCrashWhen_fetchRequestForTrackedObjects_ReturnsNil
+{
+    // given
+    self.sut = nil;
+    self.changeTracker1.fetchRequest = nil;
+    
+    self.sut = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.testSession.uiMOC changeTrackers:@[self.changeTracker1]];
+    
+    // when
+    [self.sut fetchObjectsForChangeTrackers];
+    
+    // then
+    XCTAssertNil(self.changeTracker1.objectsToUpdate);
+}
+
+- (void)testThatItDoesNotCrashWhenThePredicateReturnsNil
+{
+    // given
+    self.sut = nil;
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:ZMConversation.entityName];
+    self.changeTracker1.fetchRequest = request1;
+    
+    self.sut = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.testSession.uiMOC changeTrackers:@[self.changeTracker1]];
+    
+    // when
+    [self.sut fetchObjectsForChangeTrackers];
+    
+    // then
+    XCTAssertNil(self.changeTracker1.objectsToUpdate);
+}
+
+@end
+
+
+
+@implementation ZMChangeTrackerBootstrapTests (Internal)
+
+- (void)testThatItSortsTheRequestsByEntity
+{
+    // given
+    NSString *entityName1 = ZMConversation.entityName;
+    NSString *entityName2 = ZMUser.entityName;
+    
+    NSEntityDescription *entity1 = [self.sut entityForEntityName:entityName1];
+    NSEntityDescription *entity2 = [self.sut entityForEntityName:entityName2];
+    
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:entityName1];
+    request1.predicate = [NSPredicate predicateWithFormat:@"userDefinedName != nil"];
+    NSFetchRequest *request2 = [NSFetchRequest fetchRequestWithEntityName:entityName2];
+    request2.predicate = [NSPredicate predicateWithFormat:@"name != nil"];
+    
+    // when
+    NSMapTable *map = [self.sut sortFetchRequestsByEntity:@[request1, request2]];
+    
+    // then
+    XCTAssertEqual(map.count, 2u);
+    XCTAssertEqualObjects([map objectForKey:entity1], [NSSet setWithObject:request1.predicate]);
+    XCTAssertEqualObjects([map objectForKey:entity2], [NSSet setWithObject:request2.predicate]);
+}
+
+- (void)testThatItBundlesFetchRequestsForTheSameEntityInACompoundRequest
+{
+    // given
+    NSString *entityName = ZMConversation.entityName;
+    NSEntityDescription *entity = [self.sut entityForEntityName:entityName];
+    
+    NSPredicate *predicate1 = [NSPredicate predicateWithFormat:@"property1 != nil"];
+    NSPredicate *predicate2 = [NSPredicate predicateWithFormat:@"property2 != nil"];
+    
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request1.predicate = predicate1;
+    
+    NSFetchRequest *request2 = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request2.predicate = predicate2;
+    
+    // when
+    NSMapTable *map = [self.sut sortFetchRequestsByEntity:@[request1, request2]];
+    
+    // then
+    NSSet *expected = [NSSet setWithArray:@[predicate1, predicate2]];
+    XCTAssertEqual(map.count, 1u);
+    XCTAssertEqualObjects([map objectForKey:entity], expected);
+}
+
+
+- (void)testThatItDoesNotAddRequestsWithoutPredicate
+{
+    // given
+    NSString *entityName = ZMConversation.entityName;
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    
+    // when
+    NSMapTable *map = [self.sut sortFetchRequestsByEntity:@[request]];
+    
+    // then
+    XCTAssertEqual(map.count, 0u);
+}
+
+- (void)testThatItFetchesTheObjectsAndSortsThemByEntity
+{
+    // given
+    NSString *convEntityName = ZMConversation.entityName;
+    NSString *userEntityName = ZMUser.entityName;
+    
+    NSEntityDescription *entity1 = [self.sut entityForEntityName:convEntityName];
+    NSEntityDescription *entity2 = [self.sut entityForEntityName:userEntityName];
+    
+    NSFetchRequest *request1 = [NSFetchRequest fetchRequestWithEntityName:convEntityName];
+    request1.predicate = [NSPredicate predicateWithFormat:@"userDefinedName != nil"];
+    NSFetchRequest *request2 = [NSFetchRequest fetchRequestWithEntityName:userEntityName];
+    request2.predicate = [NSPredicate predicateWithFormat:@"name != nil"];
+    
+    // when
+    NSMapTable *entityToRequestMap = [NSMapTable strongToStrongObjectsMapTable];
+    [entityToRequestMap setObject:[NSSet setWithObject:request1.predicate] forKey:entity1];
+    [entityToRequestMap setObject:[NSSet setWithObject:request2.predicate] forKey:entity2];
+    
+    NSMapTable *map = [self.sut executeMappedFetchRequests:entityToRequestMap];
+    
+    // then
+    XCTAssertEqual(map.count, 2u);
+    NSArray *expectedResult1 = @[self.conversation1, self.conversation2];
+    NSArray *expectedResult2 = @[self.user1, self.user2];
+    
+    AssertArraysContainsSameObjects([map objectForKey:entity1], expectedResult1);
+    AssertArraysContainsSameObjects([map objectForKey:entity2], expectedResult2);
+}
+
+- (void)testThatItDoesNotAddEmptyResults
+{
+    // given
+    NSString *entityName = ZMConnection.entityName;
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request.predicate = [NSPredicate predicateWithFormat:@"status == 0", self.user1];
+    
+    // when
+    NSMapTable *entityToRequestMap = [NSMapTable strongToStrongObjectsMapTable];
+    [entityToRequestMap setObject:[NSSet setWithObject:request.predicate] forKey:entityName];
+    NSMapTable *map = [self.sut executeMappedFetchRequests:entityToRequestMap];
+    
+    // then
+    XCTAssertEqual(map.count, 0u);
+}
+
+@end
+

--- a/WireRequestStrategyTests/ZMSyncOperationSetTests.m
+++ b/WireRequestStrategyTests/ZMSyncOperationSetTests.m
@@ -1,0 +1,561 @@
+// 
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+// 
+
+
+@import ZMCDataModel;
+@import ZMTesting;
+
+#import "ZMSyncOperationSet.h"
+#import "MockEntity.h"
+#import "MockEntity2.h"
+#import "MockModelObjectContextFactory.h"
+
+
+@interface ZMSyncOperationSetTests : ZMTBaseTest
+
+@property (nonatomic) ZMSyncOperationSet *sut;
+@property (nonatomic) NSManagedObjectContext *testMOC;
+
+@end
+
+
+@implementation ZMSyncOperationSetTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.testMOC = [MockModelObjectContextFactory testContext];
+    self.sut = [[ZMSyncOperationSet alloc] init];
+    self.sut.sortDescriptors = [MockEntity sortDescriptorsForUpdating];
+}
+
+- (void)tearDown
+{
+    self.sut = nil;
+    [super tearDown];
+}
+
+- (void)testThatItReturnsAnObjectAfterItHasBeenAdded
+{
+    // given
+    MockEntity *mo = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    
+    // when
+    [self.sut addObjectToBeSynchronized:mo];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo);
+}
+
+- (void)testThatItReturnsTheFirstObjectIfItIsNotStarted
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo1.field = 1;
+    MockEntity *mo2 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo2.field = 2;
+    MockEntity *mo3 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo3.field = 3;
+    
+    // when
+    [self.sut addObjectToBeSynchronized:mo1];
+    [self.sut addObjectToBeSynchronized:mo2];
+    [self.sut addObjectToBeSynchronized:mo3];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 3u);
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo1);
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo1);
+}
+
+- (void)testThatItDoesNotReturnAnObjectAfterItIsStarted
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    ZMManagedObject *firstObject = [self.sut nextObjectToSynchronize];
+    
+    // when
+    [self.sut didStartSynchronizingKeys:nil forObject:firstObject];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    XCTAssertNil([self.sut nextObjectToSynchronize]);
+}
+
+
+- (void)testThatItDoesNotReturnObjectAfterItIsStartedEvenIfItIsAddedAgain
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    ZMManagedObject *firstObject = [self.sut nextObjectToSynchronize];
+    
+    // when
+    [self.sut didStartSynchronizingKeys:nil forObject:firstObject];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    XCTAssertNil([self.sut nextObjectToSynchronize]);
+}
+
+- (void)testThatItReturnsAnObjectAgainAfterSynchronizationFailsWithATemporaryError
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    ZMManagedObject *firstObject = [self.sut nextObjectToSynchronize];
+    
+    // when
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:nil forObject:firstObject];
+    [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:firstObject result:ZMTransportResponseStatusTemporaryError];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    XCTAssertEqualObjects(mo1, [self.sut nextObjectToSynchronize]);
+}
+
+- (void)testThatItReturnsAnObjectAgainAfterSynchronizationFailsWithATryAgainLaterError
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    ZMManagedObject *firstObject = [self.sut nextObjectToSynchronize];
+    
+    // when
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:nil forObject:firstObject];
+    [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:firstObject result:ZMTransportResponseStatusTryAgainLater];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    XCTAssertEqualObjects(mo1, [self.sut nextObjectToSynchronize]);
+}
+
+- (void)testThatItDoesNotReturnAnObjectAgainAfterSynchronizationWasSuccessful
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    ZMManagedObject *firstObject = [self.sut nextObjectToSynchronize];
+    
+    // when
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:nil forObject:firstObject];
+    id keys = [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:firstObject result:ZMTransportResponseStatusSuccess];
+    [self.sut removeUpdatedObject:firstObject syncToken:token synchronizedKeys:keys];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 0u);
+    XCTAssertNil([self.sut nextObjectToSynchronize]);
+}
+
+- (void)testThatItDoesReturnAnObjectAgainAfterSynchronizationWasSuccessfulAndItWasReAdded
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    ZMManagedObject *firstObject = [self.sut nextObjectToSynchronize];
+    
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:nil forObject:firstObject];
+    [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:firstObject result:ZMTransportResponseStatusSuccess];
+    
+    // when
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    XCTAssertEqualObjects(mo1, [self.sut nextObjectToSynchronize]);
+}
+
+
+- (void)testThatItReturnsObjectsInTheUpdateOrder;
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo1.field = 10;
+    MockEntity *mo2 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo2.field = 90;
+    MockEntity *mo3 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo3.field = 20;
+
+    [self.sut addObjectToBeSynchronized:mo1];
+    [self.sut addObjectToBeSynchronized:mo2];
+    [self.sut addObjectToBeSynchronized:mo3];
+
+    // when / then
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo1);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo1];
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo3);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo3];
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo2);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo2];
+    XCTAssertNil([self.sut nextObjectToSynchronize]);
+    
+    XCTAssertEqual(self.sut.count, 3u);
+}
+
+- (void)testThatItReturnsObjectsInTheUpdateOrder_2
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo1.field = 30;
+    MockEntity *mo2 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo2.field = 20;
+    MockEntity *mo3 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo3.field = 10;
+    
+    [self.sut addObjectToBeSynchronized:mo3];
+    [self.sut addObjectToBeSynchronized:mo2];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    // when / then
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo3);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo3];
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo2);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo2];
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo1);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo1];
+    XCTAssertNil([self.sut nextObjectToSynchronize]);
+}
+
+- (void)testThatItTheUpdateOrderIsEvaluatesAtRetrievalTime
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo1.field = 10;
+    MockEntity *mo2 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo2.field = 20;
+    MockEntity *mo3 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo3.field = 30;
+    
+    [self.sut addObjectToBeSynchronized:mo3];
+    [self.sut addObjectToBeSynchronized:mo2];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    mo1.field = 30;
+    mo2.field = 20;
+    mo3.field = 10;
+    
+    // when / then
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo3);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo3];
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo2);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo2];
+    XCTAssertEqual([self.sut nextObjectToSynchronize], mo1);
+    [self.sut didStartSynchronizingKeys:nil forObject:mo1];
+    XCTAssertNil([self.sut nextObjectToSynchronize]);
+}
+
+
+- (void)testThatItReturnsSynchronizedKeysAfterSuccessfullySynchronizing
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    NSSet *expectedKeys = [NSSet setWithObjects:@"field", @"field2", nil];
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:expectedKeys forObject:mo1];
+    
+    // when
+    NSSet *synchronizedKeys = [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:mo1 result:ZMTransportResponseStatusSuccess];
+    
+    // then
+    XCTAssertEqualObjects(synchronizedKeys, expectedKeys);
+}
+
+- (void)testThatItReturnsNoSynchronizedKeysAfterAFailedSynchronizationWithTemporaryError
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    NSSet *changedKeys = [NSSet setWithObjects:@"field", @"field2", nil];
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:changedKeys forObject:mo1];
+    
+    // when
+    NSSet *synchronizedKeys = [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:mo1 result:ZMTransportResponseStatusTemporaryError];
+    
+    // then
+    XCTAssertEqualObjects(synchronizedKeys, [NSSet set]);
+}
+
+- (void)testThatItReturnsAllSynchronizedKeysAfterAFailedSynchronizationWithPermanentError
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    NSSet *changedKeys = [NSSet setWithObjects:@"field", @"field2", nil];
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:changedKeys forObject:mo1];
+    
+    // when
+    NSSet *synchronizedKeys = [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:mo1 result:ZMTransportResponseStatusPermanentError];
+    
+    // then
+    XCTAssertEqualObjects(synchronizedKeys, changedKeys);
+}
+
+- (void)testThatItDoesNotSynchronizeKeysIfTheirValuesChange
+{
+    
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo1.field = 1;
+    mo1.field2 = @"1";
+    
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    NSSet *changedKeys = [NSSet setWithObjects:@"field", @"field2", nil];
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:changedKeys forObject:mo1];
+    
+    mo1.field = 2;
+    mo1.field2 = @"2";
+    
+    // when
+    NSSet *synchronizedKeys = [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:mo1 result:ZMTransportResponseStatusSuccess];
+    
+    // then
+    XCTAssertEqualObjects(synchronizedKeys, [NSSet set]);
+    XCTAssertEqualObjects(mo1, [self.sut nextObjectToSynchronize]);
+}
+
+- (void)testThatItSynchronizesOnlyOneKeyOutOfTwoIfItsValueDidNotChange
+{
+    
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    mo1.field = 1;
+    mo1.field2 = @"1";
+    
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    NSSet *changedKeys = [NSSet setWithObjects:@"field", @"field2", nil];
+    ZMSyncToken *token = [self.sut didStartSynchronizingKeys:changedKeys forObject:mo1];
+    
+    mo1.field = 2;
+    
+    // when
+    NSSet *synchronizedKeys = [self.sut keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:mo1 result:ZMTransportResponseStatusSuccess];
+    
+    // then
+    XCTAssertEqualObjects(synchronizedKeys, [NSSet setWithObject:@"field2"]);
+    XCTAssertEqualObjects(mo1, [self.sut nextObjectToSynchronize]);
+}
+
+- (void)testThatItDeletesASyncObject
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    // when
+    [self.sut removeObject:mo1];
+    
+    // then
+    XCTAssertNil([self.sut nextObjectToSynchronize]);
+}
+
+@end
+
+
+
+@implementation ZMSyncOperationSetTests (PartialUpdates)
+
+- (void)testThatItReturnsAnObjectWithNoRemainingKeysAfterItHasBeenAdded
+{
+    // given
+    MockEntity *mo = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    
+    // when
+    [self.sut addObjectToBeSynchronized:mo];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    NSSet *keys;
+    XCTAssertEqual([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil], mo);
+    XCTAssertNil(keys);
+}
+
+- (void)testThatItReturnsTheSameObjectWithRemainingKeysAfterSettingRemainingKeys;
+{
+    // given
+    MockEntity *mo = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    
+    // when
+    [self.sut addObjectToBeSynchronized:mo];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    NSSet *keys;
+    XCTAssertEqual([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil], mo);
+    XCTAssertNil(keys);
+    
+    // when
+    NSSet *remaininKeys = [NSSet setWithObjects:@"A", @"B", nil];
+    [self.sut setRemainingKeys:remaininKeys forObject:mo];
+    
+    // then
+    XCTAssertGreaterThanOrEqual(self.sut.count, 1u);
+    XCTAssertEqual([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil], mo);
+    XCTAssertEqual(keys, remaininKeys);
+    
+    // when
+    remaininKeys = [NSSet setWithObjects:@"A", nil];
+    [self.sut setRemainingKeys:remaininKeys forObject:mo];
+    
+    // then
+    XCTAssertGreaterThanOrEqual(self.sut.count, 1u);
+    XCTAssertEqual([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil], mo);
+    XCTAssertEqual(keys, remaininKeys);
+}
+
+- (void)testThatItDoesNotReturnTheSameObjectAfterSettingTheRemainingKeysToEmpty;
+{
+    // given
+    MockEntity *mo = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    
+    // when
+    [self.sut addObjectToBeSynchronized:mo];
+    
+    // then
+    XCTAssertEqual(self.sut.count, 1u);
+    NSSet *keys;
+    XCTAssertEqual([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil], mo);
+    XCTAssertNil(keys);
+    
+    // when
+    NSSet *remaininKeys = [NSSet setWithObjects:@"field2", @"field3", nil];
+    [self.sut didStartSynchronizingKeys:remaininKeys forObject:mo];
+    [self.sut setRemainingKeys:remaininKeys forObject:mo];
+    remaininKeys = [NSSet set];
+    [self.sut setRemainingKeys:remaininKeys forObject:mo];
+    
+    // then
+    XCTAssertNil([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil]);
+    XCTAssertNil(keys);
+}
+
+- (void)testThatSettingTheRemainingKeysToEmptHasNoEffectWhenThatObjectDidNotHaveRemainingKeys
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    // when
+    [self.sut setRemainingKeys:[NSSet set] forObject:mo1];
+    
+    // then
+    NSSet *keys;
+    XCTAssertEqual([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil], mo1);
+    XCTAssertNil(keys);
+}
+
+- (void)testThatItDeletesASyncObjectWhenSettingTheRemainingKeysToEmptyAfterSettingTheRemainingKeys
+{
+    // given
+    MockEntity *mo1 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    [self.sut addObjectToBeSynchronized:mo1];
+    
+    // when
+    NSSet *keys = [NSSet setWithObject:@"field2"];
+    [self.sut didStartSynchronizingKeys:keys forObject:mo1];
+    [self.sut setRemainingKeys:keys forObject:mo1];
+    [self.sut setRemainingKeys:[NSSet set] forObject:mo1];
+    
+    // then
+    NSSet *keys2;
+    XCTAssertNil([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys2 notInOperationSet:nil]);
+    XCTAssertNil(keys2);
+}
+
+- (void)testThatItReturnsAnObjectWithNoRemainingKeysWhenItIsAddedAgainAfterSettingRemainingKeys
+{
+    // given
+    MockEntity *mo = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    
+    // when
+    [self.sut addObjectToBeSynchronized:mo];
+    NSSet *remaininKeys = [NSSet setWithObjects:@"A", @"B", nil];
+    [self.sut setRemainingKeys:remaininKeys forObject:mo];
+    [self.sut addObjectToBeSynchronized:mo];
+    
+    // then
+    XCTAssertGreaterThanOrEqual(self.sut.count, 1u);
+    NSSet *keys;
+    XCTAssertEqual([self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:nil], mo);
+    XCTAssertNil(keys);
+}
+
+- (void)testThatItReturnsTheFirstObjectThatIsNotInAnotherSet
+{
+    // given
+    MockEntity *mo = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    MockEntity *mo2 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    MockEntity *mo3 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+
+    
+    [self.sut addObjectToBeSynchronized:mo];
+    [self.sut addObjectToBeSynchronized:mo2];
+    [self.sut addObjectToBeSynchronized:mo3];
+    
+    ZMSyncOperationSet *otherSet = [[ZMSyncOperationSet alloc] init];
+    [otherSet addObjectToBeSynchronized:mo];
+    [otherSet addObjectToBeSynchronized:mo2];
+    
+    // when
+    NSSet *keys;
+    ZMManagedObject *nextObject = [self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:otherSet];
+    
+    // then
+    XCTAssertEqualObjects(nextObject, mo3);
+}
+
+- (void)testThatItReturnsNilIfAllObjectsAreInOtherSet
+{
+    // given
+    MockEntity *mo = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    MockEntity *mo2 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    MockEntity *mo3 = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    
+    
+    [self.sut addObjectToBeSynchronized:mo];
+    [self.sut addObjectToBeSynchronized:mo2];
+    [self.sut addObjectToBeSynchronized:mo3];
+    
+    ZMSyncOperationSet *otherSet = [[ZMSyncOperationSet alloc] init];
+    [otherSet addObjectToBeSynchronized:mo];
+    [otherSet addObjectToBeSynchronized:mo2];
+    [otherSet addObjectToBeSynchronized:mo3];
+    
+    // when
+    NSSet *keys;
+    ZMManagedObject *nextObject = [self.sut nextObjectToSynchronizeWithRemainingKeys:&keys notInOperationSet:otherSet];
+    
+    // then
+    XCTAssertNil(nextObject);
+}
+
+@end


### PR DESCRIPTION
Two classes who was moved into this framework still had their corresponding tests in the `sync-engine`. This PR move them here.