### PR TITLE
Add `ready` state to ZMSingleRequestSync

### DIFF
--- a/WireRequestStrategy/ZMSingleRequestSync.h
+++ b/WireRequestStrategy/ZMSingleRequestSync.h
@@ -33,6 +33,7 @@
 
 typedef NS_ENUM(int, ZMSingleRequestProgress) {
     ZMSingleRequestIdle = 0,
+    ZMSingleRequestReady,
     ZMSingleRequestInProgress,
     ZMSingleRequestCompleted
 };

--- a/WireRequestStrategy/ZMSingleRequestSync.m
+++ b/WireRequestStrategy/ZMSingleRequestSync.m
@@ -61,7 +61,7 @@
 {
     ++self.requestUniqueCounter;
     self.currentRequest = nil;
-    self.status = ZMSingleRequestInProgress;
+    self.status = ZMSingleRequestReady;
 }
 
 - (void)readyForNextRequestIfNotBusy
@@ -74,13 +74,15 @@
 - (ZMTransportRequest *)nextRequest
 {
     id<ZMSingleRequestTranscoder> transcoder = self.transcoder;
-    if(self.currentRequest == nil && self.status == ZMSingleRequestInProgress) {
+    if(self.currentRequest == nil && self.status == ZMSingleRequestReady) {
         ZMTransportRequest *request = [transcoder requestForSingleRequestSync:self];
         [request setDebugInformationTranscoder:transcoder];
 
         self.currentRequest = request;
         if(request == nil) {
             self.status = ZMSingleRequestCompleted;
+        } else {
+            self.status = ZMSingleRequestInProgress;
         }
         const int currentCounter = self.requestUniqueCounter;
         ZM_WEAK(self);
@@ -116,7 +118,7 @@
             break;
         }
         case ZMTransportResponseStatusTemporaryError: {
-            self.status = ZMSingleRequestInProgress;
+            self.status = ZMSingleRequestReady;
             break;
         }
     }


### PR DESCRIPTION
# What's in this PR?

The `ZMSingleRequestSync` reported a progress state of `ZMSingleRequestInProgress ` even when the request was not actually being performed at the moment, which is why a new state `ZMSingleRequestProgressReady` has been introduced. Following the new states of a single request sync:

* Initially the state of a created `ZMSingleRequestSync` is `ZMSingleRequestIdle`.
* When `readyForNextRequest ` is called the state changes to `ZMSingleRequestReady`, requests can now be created by calling `nextRequest`.
* If a request gets created by the transcoder owning the sync the state changes to `ZMSingleRequestInProgress`, if not it changes to `ZMSingleRequestCompleted`.
* If the completion state is reset the sync returns to its initial state `ZMSingleRequestIdle`.

This change is needed as the `ZMMissingUpdateEventsTranscoder` now also acts as a request strategy and needs to now when it's underlying paginated request sync is running so that it can return the request for the next page.
