### PR TITLE
Relax type constraint on dependency for objects

### DIFF
--- a/WireRequestStrategy/ZMDependentObjects.h
+++ b/WireRequestStrategy/ZMDependentObjects.h
@@ -25,11 +25,11 @@
 
 @interface ZMDependentObjects : NSObject
 
-- (void)addManagedObject:(ZMManagedObject *)managedObject withDependency:(ZMManagedObject *)dependency;
+- (void)addManagedObject:(ZMManagedObject *)managedObject withDependency:(NSObject *)dependency;
 
 /// When the @c block returns @c YES the object will get removed from the reciver, otherwise it will stay registered with the given dependency.
-- (void)enumerateManagedObjectsForDependency:(ZMManagedObject *)dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
+- (void)enumerateManagedObjectsForDependency:(NSObject *)dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
 
-- (ZMManagedObject *)anyDependencyForObject:(ZMManagedObject *)dependant;
+- (NSObject *)anyDependencyForObject:(ZMManagedObject *)dependant;
 
 @end

--- a/WireRequestStrategy/ZMDependentObjects.m
+++ b/WireRequestStrategy/ZMDependentObjects.m
@@ -40,7 +40,7 @@
     return self;
 }
 
-- (void)addManagedObject:(ZMManagedObject *)dependantObject withDependency:(ZMManagedObject *)dependency;
+- (void)addManagedObject:(ZMManagedObject *)dependantObject withDependency:(NSObject *)dependency;
 {
     VerifyReturn(dependantObject != nil);
     VerifyReturn(dependency != nil);
@@ -54,10 +54,10 @@
     }
 }
 
-- (ZMManagedObject *)anyDependencyForObject:(ZMManagedObject *)dependant
+- (NSObject *)anyDependencyForObject:(ZMManagedObject *)dependant
 {
     NSEnumerator *keyEnumbertor = [self.dependenciesToDependants keyEnumerator];
-    ZMManagedObject *dependency;
+    NSObject *dependency;
     while ((dependency = keyEnumbertor.nextObject)) {
         NSOrderedSet *dependencies = [self.dependenciesToDependants objectForKey:dependency];
         if ([dependencies containsObject:dependant]) {
@@ -67,7 +67,7 @@
     return nil;
 }
 
-- (void)enumerateManagedObjectsForDependency:(ZMManagedObject *)dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
+- (void)enumerateManagedObjectsForDependency:(NSObject *)dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
 {
     VerifyReturn(dependency != nil);
     NSMutableOrderedSet *trackedDependants = [self.dependenciesToDependants objectForKey:dependency];

--- a/WireRequestStrategy/ZMUpstreamInsertedObjectSync.m
+++ b/WireRequestStrategy/ZMUpstreamInsertedObjectSync.m
@@ -137,7 +137,7 @@
 - (void)checkForUpdatedDependency:(ZMManagedObject *)existingDependency;
 {
     [self.insertedObjectsWithDependencies enumerateManagedObjectsForDependency:existingDependency withBlock:^BOOL(ZMManagedObject *mo) {
-        ZMManagedObject *newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        NSObject *newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (newDependency == nil) {
             [self.insertedObjects addObjectToSynchronize:mo];
             return YES;
@@ -159,7 +159,7 @@
 - (BOOL)addInsertedObject:(ZMManagedObject *)mo
 {
     if (self.insertedObjectsWithDependencies) {
-        ZMManagedObject *dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        NSObject *dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (dependency != nil) {
             [self.insertedObjectsWithDependencies addManagedObject:mo withDependency:dependency];
             return NO;

--- a/WireRequestStrategy/ZMUpstreamModifiedObjectSync.m
+++ b/WireRequestStrategy/ZMUpstreamModifiedObjectSync.m
@@ -178,7 +178,7 @@ ZM_EMPTY_ASSERTING_INIT();
 - (void)checkForUpdatedDependency:(ZMManagedObject *)existingDependency;
 {
     [self.updatedObjectsWithDependencies enumerateManagedObjectsForDependency:existingDependency withBlock:^BOOL(ZMManagedObject *mo) {
-        ZMManagedObject *newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        NSObject *newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (newDependency == nil) {
             [self addUpdatedObjectWithoutDependency:mo];
             return YES;
@@ -204,7 +204,7 @@ ZM_EMPTY_ASSERTING_INIT();
 - (void)addUpdatedObject:(ZMManagedObject *)mo
 {
     if (self.updatedObjectsWithDependencies) {
-        ZMManagedObject *dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        NSObject *dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (dependency != nil) {
             [self.updatedObjectsWithDependencies addManagedObject:mo withDependency:dependency];
             return;
@@ -222,7 +222,7 @@ ZM_EMPTY_ASSERTING_INIT();
     }
     
     //if we still has a dependency for this object we don't sync it
-    ZMManagedObject *dependency = [self.updatedObjectsWithDependencies anyDependencyForObject:objectWithKeys.object];
+    NSObject *dependency = [self.updatedObjectsWithDependencies anyDependencyForObject:objectWithKeys.object];
     if (dependency != nil) {
         return nil;
     }

--- a/WireRequestStrategy/ZMUpstreamTranscoder.h
+++ b/WireRequestStrategy/ZMUpstreamTranscoder.h
@@ -48,7 +48,7 @@
 /// at which time the upstream object sync will ask the transcoder again.
 ///
 /// Dependant -> depends on -> dependency
-- (ZMManagedObject * _Nullable)dependentObjectNeedingUpdateBeforeProcessingObject:(ZMManagedObject * _Nonnull)dependant;
+- (NSObject * _Nullable)dependentObjectNeedingUpdateBeforeProcessingObject:(ZMManagedObject * _Nonnull)dependant;
 
 /// If implemented, the upstream object sync will call this when an upstream request timed out. Having a request
 /// that might time out but not implementing this will trigger an assertion.


### PR DESCRIPTION
# Reason for this pull request
There is no reason to restrict object dependency (dependency to resolve before they can be synchronized to the backend) to managed object. Any type of object could be a dependency.