### PR TITLE
Relax constraints even more

### DIFF
--- a/WireRequestStrategy/ZMDependentObjects.h
+++ b/WireRequestStrategy/ZMDependentObjects.h
@@ -25,11 +25,11 @@
 
 @interface ZMDependentObjects : NSObject
 
-- (void)addManagedObject:(ZMManagedObject *)managedObject withDependency:(NSObject *)dependency;
+- (void)addManagedObject:(ZMManagedObject *)managedObject withDependency:(id)dependency;
 
 /// When the @c block returns @c YES the object will get removed from the reciver, otherwise it will stay registered with the given dependency.
-- (void)enumerateManagedObjectsForDependency:(NSObject *)dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
+- (void)enumerateManagedObjectsForDependency:(id )dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
 
-- (NSObject *)anyDependencyForObject:(ZMManagedObject *)dependant;
+- (id)anyDependencyForObject:(ZMManagedObject *)dependant;
 
 @end

--- a/WireRequestStrategy/ZMDependentObjects.m
+++ b/WireRequestStrategy/ZMDependentObjects.m
@@ -40,7 +40,7 @@
     return self;
 }
 
-- (void)addManagedObject:(ZMManagedObject *)dependantObject withDependency:(NSObject *)dependency;
+- (void)addManagedObject:(ZMManagedObject *)dependantObject withDependency:(id)dependency;
 {
     VerifyReturn(dependantObject != nil);
     VerifyReturn(dependency != nil);
@@ -54,10 +54,10 @@
     }
 }
 
-- (NSObject *)anyDependencyForObject:(ZMManagedObject *)dependant
+- (id)anyDependencyForObject:(ZMManagedObject *)dependant
 {
     NSEnumerator *keyEnumbertor = [self.dependenciesToDependants keyEnumerator];
-    NSObject *dependency;
+    id dependency;
     while ((dependency = keyEnumbertor.nextObject)) {
         NSOrderedSet *dependencies = [self.dependenciesToDependants objectForKey:dependency];
         if ([dependencies containsObject:dependant]) {
@@ -67,7 +67,7 @@
     return nil;
 }
 
-- (void)enumerateManagedObjectsForDependency:(NSObject *)dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
+- (void)enumerateManagedObjectsForDependency:(id)dependency withBlock:(BOOL(^)(ZMManagedObject *managedObject))block;
 {
     VerifyReturn(dependency != nil);
     NSMutableOrderedSet *trackedDependants = [self.dependenciesToDependants objectForKey:dependency];

--- a/WireRequestStrategy/ZMUpstreamInsertedObjectSync.m
+++ b/WireRequestStrategy/ZMUpstreamInsertedObjectSync.m
@@ -137,7 +137,7 @@
 - (void)checkForUpdatedDependency:(ZMManagedObject *)existingDependency;
 {
     [self.insertedObjectsWithDependencies enumerateManagedObjectsForDependency:existingDependency withBlock:^BOOL(ZMManagedObject *mo) {
-        NSObject *newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        id newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (newDependency == nil) {
             [self.insertedObjects addObjectToSynchronize:mo];
             return YES;
@@ -159,7 +159,7 @@
 - (BOOL)addInsertedObject:(ZMManagedObject *)mo
 {
     if (self.insertedObjectsWithDependencies) {
-        NSObject *dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        id dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (dependency != nil) {
             [self.insertedObjectsWithDependencies addManagedObject:mo withDependency:dependency];
             return NO;

--- a/WireRequestStrategy/ZMUpstreamModifiedObjectSync.m
+++ b/WireRequestStrategy/ZMUpstreamModifiedObjectSync.m
@@ -178,7 +178,7 @@ ZM_EMPTY_ASSERTING_INIT();
 - (void)checkForUpdatedDependency:(ZMManagedObject *)existingDependency;
 {
     [self.updatedObjectsWithDependencies enumerateManagedObjectsForDependency:existingDependency withBlock:^BOOL(ZMManagedObject *mo) {
-        NSObject *newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        id newDependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (newDependency == nil) {
             [self addUpdatedObjectWithoutDependency:mo];
             return YES;
@@ -204,7 +204,7 @@ ZM_EMPTY_ASSERTING_INIT();
 - (void)addUpdatedObject:(ZMManagedObject *)mo
 {
     if (self.updatedObjectsWithDependencies) {
-        NSObject *dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
+        id dependency = [self.transcoder dependentObjectNeedingUpdateBeforeProcessingObject:mo];
         if (dependency != nil) {
             [self.updatedObjectsWithDependencies addManagedObject:mo withDependency:dependency];
             return;
@@ -222,7 +222,7 @@ ZM_EMPTY_ASSERTING_INIT();
     }
     
     //if we still has a dependency for this object we don't sync it
-    NSObject *dependency = [self.updatedObjectsWithDependencies anyDependencyForObject:objectWithKeys.object];
+    id dependency = [self.updatedObjectsWithDependencies anyDependencyForObject:objectWithKeys.object];
     if (dependency != nil) {
         return nil;
     }

--- a/WireRequestStrategy/ZMUpstreamTranscoder.h
+++ b/WireRequestStrategy/ZMUpstreamTranscoder.h
@@ -48,7 +48,7 @@
 /// at which time the upstream object sync will ask the transcoder again.
 ///
 /// Dependant -> depends on -> dependency
-- (NSObject * _Nullable)dependentObjectNeedingUpdateBeforeProcessingObject:(ZMManagedObject * _Nonnull)dependant;
+- (id _Nullable)dependentObjectNeedingUpdateBeforeProcessingObject:(ZMManagedObject * _Nonnull)dependant;
 
 /// If implemented, the upstream object sync will call this when an upstream request timed out. Having a request
 /// that might time out but not implementing this will trigger an assertion.


### PR DESCRIPTION
# Reason for this pull request
It has to be `id` to translate to `AnyObject` in Swift