### PR TITLE
Conform ZMRemoteIdentifierObjectSync to ZMRequestGenerator protocol

### DIFF
--- a/WireRequestStrategy/ZMRemoteIdentifierObjectSync.h
+++ b/WireRequestStrategy/ZMRemoteIdentifierObjectSync.h
@@ -18,6 +18,8 @@
 
 
 #import <Foundation/Foundation.h>
+#import "ZMRequestGenerator.h"
+
 
 @class ZMRemoteIdentifierObjectSync;
 @class ZMTransportRequest;
@@ -35,7 +37,7 @@
 
 
 
-@interface ZMRemoteIdentifierObjectSync : NSObject
+@interface ZMRemoteIdentifierObjectSync : NSObject <ZMRequestGenerator>
 
 - (instancetype)initWithTranscoder:(id<ZMRemoteIdentifierObjectTranscoder>)transcoder managedObjectContext:(NSManagedObjectContext *)moc;
 


### PR DESCRIPTION
# What's in this PR?

* We need to explicitly conform `ZMRemoteIdentifierObjectSync` to `ZMRequestGenerator` to avoid casting it when using it from Swift.
* Needed for https://github.com/wireapp/wire-ios-sync-engine/pull/381.