### PR TITLE
Forward the response to the downstream transcoder

### DIFF
--- a/WireRequestStrategy/ZMDownstreamObjectSync.h
+++ b/WireRequestStrategy/ZMDownstreamObjectSync.h
@@ -75,7 +75,7 @@
 @protocol ZMDownstreamTranscoder <NSObject>
 
 - (ZMTransportRequest *)requestForFetchingObject:(ZMManagedObject *)object downstreamSync:(id<ZMObjectSync>)downstreamSync;
-- (void)deleteObject:(ZMManagedObject *)object downstreamSync:(id<ZMObjectSync>)downstreamSync;
+- (void)deleteObject:(ZMManagedObject *)object withResponse:(ZMTransportResponse *)response downstreamSync:(id<ZMObjectSync>)downstreamSync;
 - (void)updateObject:(ZMManagedObject *)object withResponse:(ZMTransportResponse *)response downstreamSync:(id<ZMObjectSync>)downstreamSync;
 
 @end

--- a/WireRequestStrategy/ZMDownstreamObjectSync.m
+++ b/WireRequestStrategy/ZMDownstreamObjectSync.m
@@ -182,7 +182,7 @@
         case ZMTransportResponseStatusPermanentError:
         case ZMTransportResponseStatusExpired: {
             [self.objectsToDownload removeObject:object];
-            [transcoder deleteObject:object downstreamSync:self];
+            [transcoder deleteObject:object withResponse:response downstreamSync:self];
             break;
         }
     }

--- a/WireRequestStrategy/ZMDownstreamObjectSyncWithWhitelist.m
+++ b/WireRequestStrategy/ZMDownstreamObjectSyncWithWhitelist.m
@@ -85,9 +85,9 @@
     return [self.transcoder requestForFetchingObject:object downstreamSync:self];
 }
 
-- (void)deleteObject:(ZMManagedObject *)object downstreamSync:(id<ZMObjectSync> __unused)downstreamSync
+- (void)deleteObject:(ZMManagedObject *)object withResponse:(ZMTransportResponse *)response downstreamSync:(id<ZMObjectSync> __unused)downstreamSync
 {
-    return [self.transcoder deleteObject:object downstreamSync:self];
+    return [self.transcoder deleteObject:object withResponse:response downstreamSync:self];
 }
 
 - (void)updateObject:(ZMManagedObject *)object withResponse:(ZMTransportResponse *)response downstreamSync:(id<ZMObjectSync> __unused)downstreamSync

--- a/WireRequestStrategyTests/ZMDownstreamObjectSyncTests.m
+++ b/WireRequestStrategyTests/ZMDownstreamObjectSyncTests.m
@@ -326,19 +326,20 @@
     MockEntity *entity = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
     entity.needsToBeUpdatedFromBackend = YES;
     NSDictionary *payload = @{@"3":@4};
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload HTTPStatus:404 transportSessionError:nil];
     
     // expect
     [[[(id)self.transcoder expect] andReturn:self.dummyRequest] requestForFetchingObject:entity downstreamSync:self.sut];
     [[[(id)self.operationSet expect] andReturn:entity] nextObjectToSynchronize];
     [[(id)self.operationSet expect] didStartSynchronizingKeys:nil forObject:entity];
     [[(id)self.operationSet expect] keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:OCMOCK_ANY forObject:entity result:ZMTransportResponseStatusPermanentError];
-    [(id<ZMDownstreamTranscoder>)[(id)self.transcoder expect] deleteObject:entity downstreamSync:self.sut];
+    [(id<ZMDownstreamTranscoder>)[(id)self.transcoder expect] deleteObject:entity withResponse:response downstreamSync:self.sut];
     [(ZMSyncOperationSet *)[(id)self.operationSet stub] removeObject:entity];
     ZMTransportRequest *request = [self.sut nextRequest];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // when
-    [request completeWithResponse:[ZMTransportResponse responseWithPayload:payload HTTPStatus:404 transportSessionError:nil]];
+    [request completeWithResponse:response];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -352,12 +353,14 @@
     MockEntity *entity = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
     entity.needsToBeUpdatedFromBackend = YES;
     NSDictionary *payload = @{@"3":@4};
+
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload HTTPStatus:404 transportSessionError:nil];
     
     [[[(id)self.transcoder stub] andReturn:self.dummyRequest] requestForFetchingObject:entity downstreamSync:self.sut];
     [[[(id)self.operationSet stub] andReturn:entity] nextObjectToSynchronize];
     [[(id)self.operationSet stub] didStartSynchronizingKeys:nil forObject:entity];
     [[(id)self.operationSet stub] keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:OCMOCK_ANY forObject:entity result:ZMTransportResponseStatusPermanentError];
-    [(id<ZMDownstreamTranscoder>)[(id)self.transcoder stub] deleteObject:entity downstreamSync:self.sut];
+    [(id<ZMDownstreamTranscoder>)[(id)self.transcoder stub] deleteObject:entity withResponse:response downstreamSync:self.sut];
     ZMTransportRequest *request = [self.sut nextRequest];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -365,7 +368,7 @@
     [(ZMSyncOperationSet *)[(id)self.operationSet expect] removeObject:entity];
     
     // when
-    [request completeWithResponse:[ZMTransportResponse responseWithPayload:payload HTTPStatus:404 transportSessionError:nil]];
+    [request completeWithResponse:response];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -387,7 +390,7 @@
     [(ZMSyncOperationSet *) [(id)self.operationSet expect] keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:OCMOCK_ANY forObject:OCMOCK_ANY result:ZMTransportResponseStatusTryAgainLater];
     [(ZMSyncOperationSet *) [(id)self.operationSet reject] removeObject:OCMOCK_ANY];
     [(ZMSyncOperationSet *) [(id)self.operationSet reject] removeUpdatedObject:OCMOCK_ANY syncToken:OCMOCK_ANY synchronizedKeys:OCMOCK_ANY];
-    [[(id)self.transcoder reject] deleteObject:OCMOCK_ANY downstreamSync:OCMOCK_ANY];
+    [[(id)self.transcoder reject] deleteObject:OCMOCK_ANY withResponse:OCMOCK_ANY downstreamSync:OCMOCK_ANY];
     
     // when
     NSError *transportError = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:nil];


### PR DESCRIPTION
# What's in this PR?

* In some cases we might not want to delete the object when `deleteObject:downStreamSync` is called on a `ZMDownstreamTranscoder`.
* We now pass the `ZMTransportResponse` down to the transcoder so that it can perform additional checks on the status code for example.