### PR TITLE
Fix/markdown link preview

### DIFF
--- a/Sources/Request Strategies/Assets/Helpers/LinkPreviewPreprocessor.swift
+++ b/Sources/Request Strategies/Assets/Helpers/LinkPreviewPreprocessor.swift
@@ -36,6 +36,7 @@ private let zmLog = ZMSLog(tag: "link previews")
         self.linkPreviewDetector = linkPreviewDetector
         self.managedObjectContext = managedObjectContext
         super.init()
+        (self.linkPreviewDetector as? LinkPreviewDetector)?.delegate = self
     }
 
     public func objectsDidChange(_ objects: Set<NSManagedObject>) {
@@ -100,5 +101,19 @@ private let zmLog = ZMSLog(tag: "link previews")
         // The change processor is called as a response to a context save, 
         // which is why we need to enque a save maually here
         managedObjectContext.enqueueDelayedSave()
+    }
+}
+
+extension LinkPreviewPreprocessor: LinkPreviewDetectorDelegate {
+    public func shouldDetectURL(_ url: URL, inRange range: NSRange, inText text: String) -> Bool {
+        // We DONT want to generate link previews for markdown links such as
+        // [click me!](www.example.com). So, we get all ranges of markdown links
+        // and return false if the url range equal to one of these
+        guard let regex = try? NSRegularExpression(pattern: "\\[.+\\]\\((.+)\\)", options: []) else { return true }
+        let wholeRange = NSMakeRange(0, (text as NSString).length)
+        return  !regex
+            .matches(in: text, options: [], range: wholeRange)
+            .map { $0.rangeAt(1) }
+            .contains { NSEqualRanges($0, range) }
     }
 }

--- a/Sources/Request Strategies/Assets/Helpers/LinkPreviewPreprocessor.swift
+++ b/Sources/Request Strategies/Assets/Helpers/LinkPreviewPreprocessor.swift
@@ -108,7 +108,7 @@ extension LinkPreviewPreprocessor: LinkPreviewDetectorDelegate {
     public func shouldDetectURL(_ url: URL, inRange range: NSRange, inText text: String) -> Bool {
         // We DONT want to generate link previews for markdown links such as
         // [click me!](www.example.com). So, we get all ranges of markdown links
-        // and return false if the url range equal to one of these
+        // and return false if the url range is equal to one of these
         guard let regex = try? NSRegularExpression(pattern: "\\[.+\\]\\((.+)\\)", options: []) else { return true }
         let wholeRange = NSMakeRange(0, (text as NSString).length)
         return  !regex


### PR DESCRIPTION
## What's new in this PR?

### Issues

We don't want to generate a link preview for markdown links.

### Causes

Even though the URL of a markdown link is hidden from the user, it is still detected when processing the message and a link preview is generated (if this link is the first link in the message).

### Solutions

`LinkPreviewDetector` (see [this](https://github.com/wireapp/wire-ios-link-preview)) populates an array of detected links within a string. Currently, a link preview is generated for only the first element. Using the new `LinkPreviewDetectorDelegate`, we are now able to decide which detected links will be included in this array, and we exclude those that are detected within the markdown syntax `[link name](url)`.

Needs releases with:

- [ ] https://github.com/wireapp/wire-ios-link-preview/pull/24
