### PR TITLE
Add asserts to ensure the message sender is self

### DIFF
--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -85,6 +85,7 @@ extension AssetClientMessageRequestStrategy: ZMUpstreamTranscoder {
     public func request(forUpdating managedObject: ZMManagedObject, forKeys keys: Set<String>) -> ZMUpstreamRequest? {
         guard let message = managedObject as? ZMAssetClientMessage, let conversation = message.conversation else { return nil }
         guard let request = requestFactory.upstreamRequestForMessage(message, forConversationWithId: conversation.remoteIdentifier!) else { fatal("Unable to generate request for \(message.privateDescription)") }
+        requireInternal(true == message.sender?.isSelfUser, "Trying to send message from sender other than self: \(message.nonce?.uuidString ?? "nil nonce")")
         return ZMUpstreamRequest(keys: [#keyPath(ZMAssetClientMessage.uploadState)], transportRequest: request)
     }
 

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategy.swift
@@ -68,6 +68,7 @@ extension LinkPreviewUploadRequestStrategy : ZMUpstreamTranscoder {
         guard let message = managedObject as? ZMClientMessage else { return nil }
         guard keys.contains(ZMClientMessageLinkPreviewStateKey) else { return nil }
         guard let conversationId = message.conversation?.remoteIdentifier else { return nil }
+        requireInternal(true == message.sender?.isSelfUser, "Trying to send message from sender other than self: \(message.nonce?.uuidString ?? "nil nonce")")
         let request = requestFactory.upstreamRequestForMessage(message, forConversationWithId: conversationId)
         zmLog.debug("Sending request to send message with text: \(String(describing: message.textMessageData?.messageText)) with linkPreview: \(String(describing: message.genericMessage))")
         return ZMUpstreamRequest(keys: [ZMClientMessageLinkPreviewStateKey], transportRequest: request)

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
@@ -79,6 +79,8 @@ extension ClientMessageTranscoder: ZMUpstreamTranscoder {
                 return nil
         }
         
+        requireInternal(true == message.sender?.isSelfUser, "Trying to send message from sender other than self: \(message.nonce?.uuidString ?? "nil nonce")")
+        
         let request = self.requestFactory.upstreamRequestForMessage(message, forConversationWithId: message.conversation!.remoteIdentifier!)!
         if message.genericMessage?.hasConfirmation() == true && self.applicationStatus!.deliveryConfirmation.needsToSyncMessages {
             request.forceToVoipSession()


### PR DESCRIPTION
## What's in this PR?

Add asserts to ensure the message sender is self. The only strategies where we can't assert this are the ones sending wrapped `ZMGenericMessage` objects directly (in the form of `GenericMessageEntity`) which don't have a sender property but on the other hand are also usually "fire and forget" messages, so they don't get stored when they are received.

