### PR TITLE
 Add safe guards against sending out wrong message

### DIFF
--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
@@ -108,6 +108,24 @@ extension ClientMessageTranscoderTests {
 
 extension ClientMessageTranscoderTests {
     
+    func testThatItDoesNotGenerateARequestIfSenderIsNotSelfUser() {
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            // GIVEN
+            let text = "Lorem ipsum"
+            let message = self.groupConversation.appendMessage(withText: text) as! ZMClientMessage
+            message.sender = self.otherUser
+            self.syncMOC.saveOrRollback()
+            
+            // WHEN
+            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([message])) }
+            
+            // THEN
+            XCTAssertNil(self.sut.nextRequest())
+        }
+    }
+    
     func testThatItGeneratesARequestToSendAClientMessage() {
         self.syncMOC.performGroupedBlockAndWait {
             


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's been observed in rare circumstances that the iOS client re-sends a message from another user.

### Causes

A message is only sent out if the `delivered` property is set to false, which should never be case the for received messages. However in theory a message could be received, the context saves and the app crashes before the `delivered` property has been updated to true.

### Solutions

-  Filter messages which do not have the sender equal to the self user.
- Mark a message immediately after creating it to prevent any saves happening in between.