### PR TITLE
Fix a crash when creating link preview strategy

### DIFF
--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
@@ -80,7 +80,7 @@ public final class LinkPreviewAssetUploadRequestStrategy : AbstractRequestStrate
     
     public init(managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus, linkPreviewPreprocessor: LinkPreviewPreprocessor?, previewImagePreprocessor: ZMImagePreprocessingTracker?) {
         if nil == LinkPreviewDetectorHelper.test_debug_linkPreviewDetector() {
-            LinkPreviewDetectorHelper.setTest_debug_linkPreviewDetector(LinkPreviewDetector(resultsQueue: OperationQueue.current!))
+            LinkPreviewDetectorHelper.setTest_debug_linkPreviewDetector(LinkPreviewDetector(resultsQueue: OperationQueue.current ?? .main))
         }
         self.linkPreviewPreprocessor = linkPreviewPreprocessor ?? LinkPreviewPreprocessor(linkPreviewDetector: LinkPreviewDetectorHelper.test_debug_linkPreviewDetector()!, managedObjectContext: managedObjectContext)
         self.previewImagePreprocessor = previewImagePreprocessor ?? ZMImagePreprocessingTracker.createPreviewImagePreprocessingTracker(managedObjectContext: managedObjectContext)


### PR DESCRIPTION
## What's new in this PR?

### Issues

We force-unwrapped the current operation queue from the factory method that creates the link preview strategy, which caused a crash when it was called outside of the context of an `NSOperation`.

### Solutions

If the current operation queue is not available, we use the main operation queue as a fallback.