### PR TITLE
save context after modifiying keys to trigger fetch

### DIFF
--- a/Sources/Protocols/OTREntity.swift
+++ b/Sources/Protocols/OTREntity.swift
@@ -101,7 +101,7 @@ extension OTREntity {
             if !missingClients.intersection(recipientClients).isEmpty {
                 // make sure that we fetch those clients, even if we somehow gave up on fetching them
                 selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
-                context.saveOrRollback()
+                context.enqueueDelayedSave()
                 return selfClient
             }
         }

--- a/Sources/Protocols/OTREntity.swift
+++ b/Sources/Protocols/OTREntity.swift
@@ -97,10 +97,11 @@ extension OTREntity {
             let recipientClients = recipients.flatMap {
                 return Array($0.clients)
             }
-            // Don't block sending of messages if they that are not affected by the missing clients
+            // Don't block sending of messages if they are not affected by the missing clients
             if !missingClients.intersection(recipientClients).isEmpty {
                 // make sure that we fetch those clients, even if we somehow gave up on fetching them
                 selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
+                context.saveOrRollback()
                 return selfClient
             }
         }


### PR DESCRIPTION
## What's new in this PR?

We should save the context after setting the modified keys to trigger the fetch for the missing clients immediately.

Posting a `RequestsAvailableNotification` instead ought to do the trick, but strangely (and inexplicably) the observers didn't always receive the notification, even though the observers do not listen for notifications from a specific object, and the notifications aren't posted with a sender object. 

Even more strangely, the reason why saving the context works is because `ZMOperationLoop` in sync engine responds to the context save by posting its own `RequestsAvailableNotification`, which, as an observer of this notification, receives.

If anyone has an idea why this is, I'd love to hear it 😄 