### PR TITLE
Fix save loop

### DIFF
--- a/Sources/Protocols/OTREntity.swift
+++ b/Sources/Protocols/OTREntity.swift
@@ -99,9 +99,12 @@ extension OTREntity {
             }
             // Don't block sending of messages if they are not affected by the missing clients
             if !missingClients.intersection(recipientClients).isEmpty {
+                
                 // make sure that we fetch those clients, even if we somehow gave up on fetching them
-                selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
-                context.enqueueDelayedSave()
+                if !(selfClient.modifiedKeys?.contains(ZMUserClientMissingKey) ?? false) {
+                    selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
+                    context.enqueueDelayedSave()
+                }
                 return selfClient
             }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

SE tests gets stuck waiting for all groups to finish when a client is missing.

### Causes

Doing a save will cause the operation loop to execute objectsDidChange on all context trackers. If a client is missing we will end up in `OTREntity.dependentObjectNeedingUpdateBeforeProcessingOTREntity` which always attempt to do:
```
 selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
 context.enqueueDelayedSave()
```

This will cause the operation loop to never to stop until the missing client is fetched.

### Solutions

Only update modified keys and save if the key is actually missing from the set.