### PR TITLE
Process generic message for notifications first

### DIFF
--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
@@ -136,8 +136,17 @@ extension ClientMessageTranscoder {
     func insertMessage(from event: ZMUpdateEvent, prefetchResult: ZMFetchRequestBatchResult?) {
         switch event.type {
         case .conversationClientMessageAdd, .conversationOtrMessageAdd, .conversationOtrAssetAdd:
+            
+            // process generic message first, b/c if there is no updateResult, then
+            // a the event from a deleted message wouldn't delete the notification.
+            if event.source == .pushNotification || event.source == .webSocket {
+                if let genericMessage = ZMGenericMessage(from: event) {
+                    self.localNotificationDispatcher.process(genericMessage)
+                }
+            }
+            
             guard let updateResult = ZMOTRMessage.messageUpdateResult(from: event, in: self.managedObjectContext, prefetchResult: prefetchResult) else {
-                 return
+                return
             }
             
             updateResult.message?.markAsSent()
@@ -152,12 +161,9 @@ extension ClientMessageTranscoder {
             }
             
             if let updateMessage = updateResult.message, event.source == .pushNotification || event.source == .webSocket {
-                if let genericMessage = ZMGenericMessage(from: event) {
-                    self.localNotificationDispatcher.process(genericMessage)
-                }
                 self.localNotificationDispatcher.process(updateMessage)
-                
             }
+            
         default:
             break
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a message is deleted by the sender, the local notification on the receiver side is not removed from the lock screen / Notification Center. 

### Causes

Notification cancellation for deleted or edited messages is done by the `LocalNotificationDispatcher` in `process(genericMessage:)` (see [SyncEngine](https://github.com/wireapp/wire-ios-sync-engine/blob/f63ab47393404b044840ba37729f18379ed7dd60/Source/Notifications/Push%20notifications/LocalNotificationDispatcher%2BMessages.swift#L46)). The problem is, that update result created in this situation is nil (see [DataModel](https://github.com/wireapp/wire-ios-data-model/blob/c3da37dfa4d2053f7cac152a3808faf8da8d9cdb/Source/Model/Message/ZMOTRMessage.m#L173)). As a result, we return early, and the local notification dispatcher is not able to process the generic message.

### Solutions

Process the generic message first, then process with the update result.