### PR TITLE
Added completion handler for delivery receipts

### DIFF
--- a/Sources/Protocols/SharedProtocols.swift
+++ b/Sources/Protocols/SharedProtocols.swift
@@ -43,6 +43,8 @@ import Foundation
     
     /// Removes the messageNonce from a collection of messages to be synced and ends the background activity for sending the request
     func didConfirmMessage(_ messageNonce: UUID)
+
+    func registerCompletionHandler(completion: @escaping () -> Void)
 }
 
 

--- a/Tests/Helpers/MockObjects.swift
+++ b/Tests/Helpers/MockObjects.swift
@@ -103,7 +103,7 @@ public class MockClientRegistrationStatus: NSObject, ClientRegistrationDelegate 
 
 
 @objc public class MockConfirmationStatus : NSObject, DeliveryConfirmationDelegate {
-    
+
     public private (set) var messagesToConfirm = Set<UUID>()
     public private (set) var messagesConfirmed = Set<UUID>()
 
@@ -121,6 +121,9 @@ public class MockClientRegistrationStatus: NSObject, ClientRegistrationDelegate 
     
     public func didConfirmMessage(_ messageNonce: UUID) {
         messagesConfirmed.insert(messageNonce)
+    }
+
+    public func registerCompletionHandler(completion: @escaping () -> Void) {
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When processing push notifications we were calling the completion handler earlier than needed - we were still sending delivery receipts. This might lead to app termination because we still are processing messages, but we tell to iOS that we are done.

### Solutions

Added a possibility to register completion handler which is called when all delivery receipts have been already sent.
