### PR TITLE
Set the expectReadConfirmation flag also for asset messages

### DIFF
--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -429,11 +429,12 @@ class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         }
     }
     
-    func testThatItDoesntUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreDisabled() {
+    func testThatItUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreDisabled() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
             ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = false
             let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.oneToOneConversation)
+            message.add(message.genericMessage!.setExpectsReadConfirmation(true)!)
             
             // WHEN
             XCTAssertNotNil(self.sut.nextRequest())

--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -84,15 +84,17 @@ class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         previewAssetId: Bool = false,
         uploadState: AssetUploadState = .uploadingFullAsset,
         transferState: ZMFileTransferState = .uploading,
+        conversation: ZMConversation? = nil,
         line: UInt = #line
         ) -> ZMAssetClientMessage {
 
+        let targetConversation = conversation ?? groupConversation!
         let message: ZMAssetClientMessage!
         if isImage {
-            message = self.groupConversation.append(imageFromData: imageData) as? ZMAssetClientMessage
+            message = targetConversation.append(imageFromData: imageData) as? ZMAssetClientMessage
         } else {
             let url = Bundle(for: AssetClientMessageRequestStrategyTests.self).url(forResource: "Lorem Ipsum", withExtension: "txt")!
-            message = self.groupConversation.append(file: ZMFileMetadata(fileURL: url, thumbnail: nil)) as? ZMAssetClientMessage
+            message = targetConversation.append(file: ZMFileMetadata(fileURL: url, thumbnail: nil)) as? ZMAssetClientMessage
         }
 
         if isImage {
@@ -118,13 +120,13 @@ class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             let previewMessage = ZMGenericMessage.message(
                 content: ZMAsset.asset(withOriginal: nil, preview: previewAsset),
                 nonce: message.nonce!,
-                expiresAfter: groupConversation.messageDestructionTimeoutValue
+                expiresAfter: targetConversation.messageDestructionTimeoutValue
             )
 
             message.add(previewMessage)
             XCTAssertTrue(message.genericAssetMessage!.assetData!.hasPreview(), line: line)
             XCTAssertEqual(message.genericAssetMessage!.assetData!.preview.remote.hasAssetId(), previewAssetId, line: line)
-            XCTAssertEqual(message.isEphemeral, self.groupConversation.messageDestructionTimeoutValue != 0, line: line)
+            XCTAssertEqual(message.isEphemeral, targetConversation.messageDestructionTimeoutValue != 0, line: line)
         }
 
         if uploaded {
@@ -132,7 +134,7 @@ class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             var uploaded = ZMGenericMessage.message(
                 content: ZMAsset.asset(withUploadedOTRKey: otr, sha256: sha),
                 nonce: message.nonce!,
-                expiresAfter: groupConversation.messageDestructionTimeoutValue
+                expiresAfter: targetConversation.messageDestructionTimeoutValue
             )
             if assetId {
                 uploaded = uploaded.updatedUploaded(withAssetId: UUID.create().transportString(), token: nil)!
@@ -396,6 +398,48 @@ class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             
             self.createMessage(isImage: false, uploaded: true, assetId: true, uploadState: .uploadingThumbnail, transferState: .uploaded)
             XCTAssertNil(self.sut.nextRequest())
+        }
+    }
+    
+    func testThatItUpdatesExpectsReadConfirmationFlagWhenSendingMessageInOneToOne() {
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = true
+            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.oneToOneConversation)
+            
+            // WHEN
+            XCTAssertNotNil(self.sut.nextRequest())
+            
+            // THEN
+            XCTAssertTrue(message.genericMessage!.content!.expectsReadConfirmation())
+        }
+    }
+    
+    func testThatItDoesntUpdateExpectsReadConfirmationFlagWhenSendingMessageInGroup() {
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = true
+            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.groupConversation)
+            
+            // WHEN
+            XCTAssertNotNil(self.sut.nextRequest())
+            
+            // THEN
+            XCTAssertFalse(message.genericMessage!.content!.expectsReadConfirmation())
+        }
+    }
+    
+    func testThatItDoesntUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreDisabled() {
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = false
+            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.oneToOneConversation)
+            
+            // WHEN
+            XCTAssertNotNil(self.sut.nextRequest())
+            
+            // THEN
+            XCTAssertFalse(message.genericMessage!.content!.expectsReadConfirmation())
         }
     }
 

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
@@ -168,6 +168,27 @@ extension ClientMessageTranscoderTests {
         }
     }
     
+    func testThatItDoesntUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreDisabled() {
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            // GIVEN
+            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = false
+            let text = "Lorem ipsum"
+            let message = self.oneToOneConversation.append(text: text) as! ZMClientMessage
+            self.syncMOC.saveOrRollback()
+            
+            // WHEN
+            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([message])) }
+            if self.sut.nextRequest() == nil {
+                XCTFail()
+                return
+            }
+            
+            // THEN
+            XCTAssertFalse(message.genericMessage!.content!.expectsReadConfirmation())
+        }
+    }
+    
     func testThatItGeneratesARequestToSendAClientMessage() {
         self.syncMOC.performGroupedBlockAndWait {
             

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
@@ -168,13 +168,14 @@ extension ClientMessageTranscoderTests {
         }
     }
     
-    func testThatItDoesntUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreDisabled() {
+    func testThatItUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreDisabled() {
         self.syncMOC.performGroupedBlockAndWait {
             
             // GIVEN
             ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = false
             let text = "Lorem ipsum"
             let message = self.oneToOneConversation.append(text: text) as! ZMClientMessage
+            message.add(message.genericMessage!.setExpectsReadConfirmation(true)!.data())
             self.syncMOC.saveOrRollback()
             
             // WHEN


### PR DESCRIPTION
## What's new in this PR?

### Issues

Images and other assets would not receive read receipts in 1:1 conversations

### Causes

Asset messages are sent using another strategy which weren't setting the `expectsReadConfirmation` flag on the protobuf.