### PR TITLE
Set readReceiptsEnabledChangedRemotely

### DIFF
--- a/Sources/Request Strategies/Properties/UserPropertyRequestStrategy.swift
+++ b/Sources/Request Strategies/Properties/UserPropertyRequestStrategy.swift
@@ -65,7 +65,14 @@ extension UserProperty {
         return ZMTransportRequest(getFromPath: path)
     }
     
-    enum UpdateType {
+    typealias  UpdateType = (source: UpdateSource, method: UpdateMethod)
+    
+    enum UpdateSource {
+        case slowSync
+        case notificationStream
+    }
+    
+    enum UpdateMethod {
         case set
         case delete
         
@@ -82,7 +89,7 @@ extension UserProperty {
     }
     
     func parseUpdate(for selfUser: ZMUser, updateType: UpdateType, payload value: Any?) {
-        switch (self, updateType) {
+        switch (self, updateType.method) {
         case (.readReceiptsEnabled, .set):
             let intValue: Int
             if let numberValue = value as? Int {
@@ -97,9 +104,14 @@ extension UserProperty {
             }
             
             selfUser.setReadReceiptsEnabled(intValue > 0, synchronize: false)
-            
+            if updateType.source == .notificationStream {
+                selfUser.readReceiptsEnabledChangedRemotely = true
+            }
         case (.readReceiptsEnabled, .delete):
             selfUser.setReadReceiptsEnabled(false, synchronize: false)
+            if updateType.source == .notificationStream {
+                selfUser.readReceiptsEnabledChangedRemotely = true
+            }
         }
     }
     
@@ -236,7 +248,7 @@ extension UserPropertyRequestStrategy : ZMEventConsumer {
             let value = event.payload[UserPropertyRequestStrategy.UpdateEventValue]
             
             property.parseUpdate(for: ZMUser.selfUser(in: managedObjectContext),
-                                 updateType: UserProperty.UpdateType(eventType: event.type),
+                                 updateType: (.notificationStream, .init(eventType: event.type)),
                                  payload: value)
         }
     }
@@ -276,10 +288,14 @@ extension UserPropertyRequestStrategy: ZMSingleRequestTranscoder {
         }
         
         if response.result == .permanentError {
-            property.parseUpdate(for: ZMUser.selfUser(in: managedObjectContext), updateType: .delete, payload: nil)
+            property.parseUpdate(for: ZMUser.selfUser(in: managedObjectContext),
+                                 updateType: (.slowSync, .delete),
+                                 payload: nil)
         }
         else if response.result == .success, let payload = response.payload {
-            property.parseUpdate(for: ZMUser.selfUser(in: managedObjectContext), updateType: .set, payload: payload)
+            property.parseUpdate(for: ZMUser.selfUser(in: managedObjectContext),
+                                 updateType: (.slowSync, .set),
+                                 payload: payload)
         }
     }
 }

--- a/Sources/Request Strategies/Properties/UserPropertyRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Properties/UserPropertyRequestStrategyTests.swift
@@ -74,6 +74,7 @@ class UserPropertyRequestStrategyTests: MessagingTestBase {
             
             // then
             XCTAssertTrue(selfUser.readReceiptsEnabled)
+            XCTAssertTrue(selfUser.readReceiptsEnabledChangedRemotely)
         }
     }
     
@@ -94,6 +95,7 @@ class UserPropertyRequestStrategyTests: MessagingTestBase {
             
             // then
             XCTAssertFalse(selfUser.readReceiptsEnabled)
+            XCTAssertTrue(selfUser.readReceiptsEnabledChangedRemotely)
         }
     }
     
@@ -114,6 +116,7 @@ class UserPropertyRequestStrategyTests: MessagingTestBase {
             
             // then
             XCTAssertFalse(selfUser.readReceiptsEnabled)
+            XCTAssertTrue(selfUser.readReceiptsEnabledChangedRemotely)
         }
     }
 }
@@ -139,6 +142,7 @@ extension UserPropertyRequestStrategyTests {
             // then
             XCTAssertFalse(selfUser.needsPropertiesUpdate)
             XCTAssertTrue(selfUser.readReceiptsEnabled)
+            XCTAssertFalse(selfUser.readReceiptsEnabledChangedRemotely)
         }
     }
     
@@ -161,6 +165,7 @@ extension UserPropertyRequestStrategyTests {
             // then
             XCTAssertFalse(selfUser.needsPropertiesUpdate)
             XCTAssertFalse(selfUser.readReceiptsEnabled)
+            XCTAssertFalse(selfUser.readReceiptsEnabledChangedRemotely)
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

This is necessary in order to show user that the setting was changed remotely. Flag is displaying the dot on the user info and generating the alert.

Depends on:

- [ ] https://github.com/wireapp/wire-ios-data-model/pull/627