### PR TITLE
Fix read images expire after being sent

### DIFF
--- a/Sources/Helpers/MessageExpirationTimer.swift
+++ b/Sources/Helpers/MessageExpirationTimer.swift
@@ -41,8 +41,7 @@ public class MessageExpirationTimer: ZMMessageTimer, ZMContextChangeTracker {
     }
     
     private func timerFired(for message: ZMMessage) {
-        guard message.deliveryState != .delivered &&
-            message.deliveryState != .sent else {
+        guard message.deliveryState != .delivered && message.deliveryState != .sent && message.deliveryState != .read else {
                 return
         }
         message.expire()


### PR DESCRIPTION
## What's new in this PR?

### Issues

Image expire if they are read

### Causes

Another case of not taking the new .read delivery state into account.

### Solutions

Also check for the read state.

## Notes

As already mentioned in https://github.com/wireapp/wire-ios-data-model/pull/637 we should avoid these kind of bugs in the future. I think a good way would be to expose something like a `isDelivered` boolean which already exists on `ZMOTRMessage`. I'll not write a test for this now since I think we should re-factor this right away.