### PR TITLE
Mark as safe for app extensions

### DIFF
--- a/Resources/Configurations/WireRequestStrategy.xcconfig
+++ b/Resources/Configurations/WireRequestStrategy.xcconfig
@@ -1,4 +1,4 @@
 #include "zmc-config/ios.xcconfig"
 
-APPLICATION_EXTENSION_API_ONLY = NO
+APPLICATION_EXTENSION_API_ONLY = YES
 PRODUCT_NAME = WireRequestStrategy


### PR DESCRIPTION
## What's new in this PR?

### Issues

For some reason we did not mark this framework as safe for application extensions. This produced a warning on UI.

### Solutions

Set the flag to YES
