### PR TITLE
Make sure to upload images on the background session

### DIFF
--- a/Sources/Request Strategies/Assets/AssetV3ImageUploadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3ImageUploadRequestStrategy.swift
@@ -223,8 +223,8 @@ extension AssetV3ImageUploadRequestStrategy: ZMUpstreamTranscoder {
         guard let message = managedObject as? ZMAssetClientMessage else { fatal("Could not cast to ZMAssetClientMessage, it is \(type(of: managedObject)))") }
         guard let data = managedObjectContext.zm_fileAssetCache.assetData(message, format: .medium, encrypted: true) else { fatal("Could not find image in cache") }
         guard let retention = message.conversation.map(AssetRequestFactory.Retention.init) else { fatal("Trying to send message that doesn't have a conversation") }
-        guard let request = requestFactory.upstreamRequestForAsset(withData: data, shareable: false, retention: retention) else { fatal("Could not create asset request") }
-        
+        guard let request = requestFactory.backgroundUpstreamRequestForAsset(message: message, withData: data, shareable: false, retention: retention) else { fatal("Could not create asset request") }
+
         if message.uploadState == .uploadingThumbnail {
             request.add(ZMCompletionHandler(on: managedObjectContext) { [weak request, weak self] response in
                 message.associatedTaskIdentifier = nil


### PR DESCRIPTION
## What's new in this PR?

### Issues

After some investigation it seems that we are uploading images on foreground session which means it competes for resources with normal messages.

### Solutions

Force the upload to happen from file url and this should make it happen on background session.

