### PR TITLE
Allow requests in background for asset client message

### DIFF
--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -38,7 +38,7 @@ public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, Z
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         assetAnalytics = AssetAnalytics(managedObjectContext: managedObjectContext)
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-        configuration = .allowsRequestsDuringEventProcessing
+        configuration = [.allowsRequestsDuringEventProcessing, .allowsRequestsWhileInBackground]
 
         upstreamSync = ZMUpstreamModifiedObjectSync(
             transcoder: self,


### PR DESCRIPTION
## What's new in this PR?

### Issues

If file upload completes in the background the file is still showing as "in-progress" for the receiver.

### Causes

We would upload the file correctly, but would not update the message with the uploaded asset identifier. It was happening because the request strategy dies not allow requests in the background.

### Solutions

Allow requests in the background.
