### PR TITLE
Don't mark mark asset as isDownloading if asset is already downloaded

### DIFF
--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
@@ -76,7 +76,7 @@ fileprivate let zmLog = ZMSLog(tag: "Asset V3")
         managedObjectContext.performGroupedBlock { [weak self] in
             guard let `self` = self else { return }
             guard let object = try? self.managedObjectContext.existingObject(with: objectID) else { return }
-            guard let message = object as? ZMAssetClientMessage else { return }
+            guard let message = object as? ZMAssetClientMessage, !message.hasDownloadedFile else { return }
             message.isDownloading = true
             self.assetDownstreamObjectSync.whiteListObject(message)
             RequestAvailableNotification.notifyNewRequestsAvailable(self)


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash when timer runs out for an received ephemeral image.

### Causes

We trigger an assertion `fatalError("Cannot generate request for ...)` when attempting to generate a request to download the asset but we can't, this scenario happens because:

1. UI requests file to be downloaded every time it re-configures the asset message, this happens when the file has finished downloading.
2. This will set `isDownloading = true` but  won't generate any requests since the download filter checks if the file is already downloaded
3. The ephemeral timer runs out and we obfuscate the message, deletes downloaded files and generic messages among others
4. Since the file no longer exists locally the download filter will pass attempt generate a request
5. It fails to generate the request since the generic message is deleted

### Solutions

Don't mark a message has `isDownloading = true` if the file is already downloaded.