### PR TITLE
ZIOS-11271: App freezes when loading image collections in Search UI

### DIFF
--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
@@ -129,6 +129,10 @@ fileprivate let zmLog = ZMSLog(tag: "Asset V3")
                                       context: self.managedObjectContext.notificationContext,
                                       object: uiMessage,
                                       userInfo: userInfo).post()
+                
+                NotificationDispatcher.notifyNonCoreDataChanges(objectID: assetClientMessage.objectID,
+                                                                changedKeys: [#keyPath(ZMAssetClientMessage.hasDownloadedFile)],
+                                                                uiContext: uiMOC)
             }
             else {
                 NotificationInContext(name: AssetDownloadRequestStrategyNotification.downloadFailedNotificationName,


### PR DESCRIPTION
## What's new in this PR?

App was freezing when loading the image collection in Search UI. This was caused by multiple download operations triggered while scrolling; seems to be partially solved with the refactoring of the last week.
I've added a notification after the completion of the download that triggers `loadImage()` of  `CollectionImageCell`, because cells weren't notified about that.