### PR TITLE
Fix V2 asset request loop

### DIFF
--- a/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
@@ -72,6 +72,7 @@ import WireTransport
             guard let `self` = self else { return }
             guard let object = try? self.managedObjectContext.existingObject(with: objectID) else { return }
             guard let message = object as? ZMAssetClientMessage else { return }
+            message.isDownloading = true
             self.assetDownstreamObjectSync.whiteListObject(message)
             RequestAvailableNotification.notifyNewRequestsAvailable(self)
         }
@@ -133,8 +134,6 @@ import WireTransport
     
     public func request(forFetching object: ZMManagedObject!, downstreamSync: ZMObjectSync!) -> ZMTransportRequest! {
         if let assetClientMessage = object as? ZMAssetClientMessage {
-            
-            assetClientMessage.isDownloading = true
             
             let taskCreationHandler = ZMTaskCreatedHandler(on: managedObjectContext) { taskIdentifier in
                 assetClientMessage.associatedTaskIdentifier = taskIdentifier

--- a/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
@@ -34,7 +34,7 @@ import WireTransport
             guard let message = object as? ZMAssetClientMessage else { return false }
             guard message.version < 3 else { return false }
             
-            return !message.hasDownloadedFile && message.transferState == .uploaded
+            return !message.hasDownloadedFile && message.transferState == .uploaded && message.isDownloading
         }
         
         assetDownstreamObjectSync = ZMDownstreamObjectSyncWithWhitelist(transcoder: self,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Downloading a broken V2 asset would trigger a request loop

### Causes

Once a asset is whitelisted for downloading we will attempt to download over and over again until it succeeds, which it never happens since it's broken.

### Solutions

Check that `message.isDownloading` is true in the download filter predicate. We reset `isDownloading` to `false` when the request response arrives.