### PR TITLE
Prevent sending assets of other users & expired assets

### DIFF
--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -42,7 +42,7 @@ public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, Z
             transcoder: self,
             entityName: ZMAssetClientMessage.entityName(),
             update: AssetClientMessageRequestStrategy.updatePredicate,
-            filter: nil,
+            filter: AssetClientMessageRequestStrategy.updateFilter,
             keysToSync: [#keyPath(ZMAssetClientMessage.transferState)],
             managedObjectContext: managedObjectContext
         )
@@ -61,7 +61,15 @@ public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, Z
     }
     
     static var updatePredicate: NSPredicate {
-        return NSPredicate(format: "delivered == NO && version == 3 && transferState == \(AssetTransferState.uploaded.rawValue)")
+        return NSPredicate(format: "delivered == NO && isExpired == NO && version == 3 && transferState == \(AssetTransferState.uploaded.rawValue)")
+    }
+    
+    static var updateFilter: NSPredicate {
+        return NSPredicate { object, _ in
+            guard let message = object as? ZMMessage, let sender = message.sender  else { return false }
+                        
+            return sender.isSelfUser
+        }
     }
 
 }

--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -164,6 +164,28 @@ class AssetClientMessageRequestStrategyTests: MessagingTestBase {
     func testThatItDoesNotCreateARequestIfThereIsNoMatchingMessage() {
         XCTAssertNil(sut.nextRequest())
     }
+    
+    func testThatItDoesNotCreateARequestForAnImageMessageUploadedByOtherUser() {
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            let message = self.createMessage(uploaded: true)
+            message.sender = self.otherUser
+            
+            // THEN
+            XCTAssertNil(self.sut.nextRequest())
+        }
+    }
+    
+    func testThatItDoesNotCreateARequestForAnImageMessageWhichIsExpired() {
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            let message = self.createMessage(uploaded: true)
+            message.expire()
+            
+            // THEN
+            XCTAssertNil(self.sut.nextRequest())
+        }
+    }
 
     func testThatItDoesNotCreateARequestForAnImageMessageWithoutUploaded() {
         self.syncMOC.performGroupedBlockAndWait {


### PR DESCRIPTION
## What's new in this PR?

### Issues

After applying asset transfer migration hotfix some assets come in an unexpected state which caused it to try and create requests for messages sent by others and expired messages.

### Causes

This happens when the migration is applied twice, It will cause .failed message to be moved to the `.uploaded` state.

### Solutions

- Prevent sending of expired messages
- Prevent sending of message not created by self user