### PR TITLE
Don't attempt download assets without .uploaded in the protobuf

### DIFF
--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
@@ -39,7 +39,7 @@ fileprivate let zmLog = ZMSLog(tag: "Asset V3")
             guard let message = object as? ZMAssetClientMessage else { return false }
             guard message.version == 3 else { return false }
             
-            return !message.hasDownloadedFile && message.transferState == .uploaded && message.isDownloading
+            return !message.hasDownloadedFile && message.transferState == .uploaded && message.isDownloading && message.genericMessage?.assetData?.hasUploaded() == true
         }
         
         assetDownstreamObjectSync = ZMDownstreamObjectSyncWithWhitelist(transcoder: self,

--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
@@ -198,6 +198,26 @@ class AssetV3DownloadRequestStrategyTests: MessagingTestBase {
             XCTAssert(request.needsAuthentication)
         }
     }
+    
+    func testThatItGeneratesNoRequestsIfITheProtobufDoesNotContainUploaded() {
+        
+        syncMOC.performGroupedBlockAndWait {
+            
+            // Given
+            let message = self.conversation.append(file: ZMFileMetadata(fileURL: testDataURL)) as! ZMAssetClientMessage
+            message.updateTransferState(.uploaded, synchronize: false)
+            self.deleteDownloadedFileFor(message: message)
+            self.syncMOC.saveOrRollback()
+            message.requestFileDownload()
+        }
+        
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        syncMOC.performGroupedBlockAndWait {
+            // Then
+            XCTAssertNil(self.sut.nextRequest())
+        }
+    }
 
     func testThatItGeneratesNoRequestsIfMessageIsUploading_V3() {
         self.syncMOC.performGroupedBlockAndWait {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash after the ephemeral time runs out for an asset.

### Causes

We would try do download the asset after the content has been deleted which triggered a fatal assert.

### Solutions

Don't attempt to download assets which are missing the `.uploaded` protobuf.