### PR TITLE
Avoid attempting to send link preview for other user

### DIFF
--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategyTests.swift
@@ -56,6 +56,22 @@ class LinkPreviewUploadRequestStrategyTests: MessagingTestBase {
     func testThatItDoesNotCreateARequestInState_Processed() {
         self.verifyThatItDoesNotCreateARequest(for: .processed)
     }
+    
+    func testThatItDoesNotCreateARequestInState_Uploaded_ForOtherUser() {
+        self.syncMOC.performGroupedAndWait { moc in
+            // Given
+            let message = self.insertMessage(with: .uploaded)
+            message.sender = self.otherUser
+            
+            // When
+            self.process(message)
+        }
+        self.syncMOC.performGroupedAndWait { moc in
+            
+            // Then
+            XCTAssertNil(self.sut.nextRequest())
+        }
+    }
 
     func testThatItDoesCreateARequestInState_Uploaded() {
         self.syncMOC.performGroupedAndWait { moc in


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes on launch

### Causes

it's been observed that a client tries to send a link preview update belonging to another user, this will result in an assertion and crash the app. We hit this assertion because somehow the `linkPreviewState` has been set to `.uploaded` for a message not belonging to the self user. How this can happen is still under investigation.

### Solutions

Until we find out how `linkPreviewState` can get modified for other user's messages we add an  update filter which avoids the crash.