### PR TITLE
Don't insert delivery confirmation when processing incoming message

### DIFF
--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
@@ -159,16 +159,7 @@ extension ClientMessageTranscoder {
             }
             
             updateResult.message?.markAsSent()
-                        
-            if type(of: self.applicationStatus!.deliveryConfirmation).sendDeliveryReceipts {
-                if updateResult.needsConfirmation {
-                    let confirmation = updateResult.message!.confirmDelivery()!
-                    if event.source == .pushNotification {
-                        self.applicationStatus!.deliveryConfirmation.needsToConfirmMessage(confirmation.nonce!)
-                    }
-                }
-            }
-            
+                                    
             if let updateMessage = updateResult.message, event.source == .pushNotification || event.source == .webSocket {
                 self.localNotificationDispatcher.process(updateMessage)
             }

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests+MessageConfirmation.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests+MessageConfirmation.swift
@@ -25,31 +25,12 @@ import WireRequestStrategy
 // MARK: - Confirmation message
 extension ClientMessageTranscoderTests {
     
-    func testThatItInsertAConfirmationMessageWhenReceivingAnEvent() {
-        self.syncMOC.performGroupedBlockAndWait {
-            
-            // GIVEN
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo", conversation: self.oneToOneConversation)
-            
-            // WHEN
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            self.syncMOC.saveOrRollback()
-            
-            // THEN
-            guard let confirmationMessage = self.lastConfirmationMessage else { return XCTFail() }
-            XCTAssertTrue(confirmationMessage.genericMessage!.hasConfirmation())
-            XCTAssertEqual(confirmationMessage.genericMessage!.confirmation.firstMessageId, event.messageNonce()!.transportString())
-        }
-    }
-    
     func testThatItSendsAConfirmationMessage() {
         self.syncMOC.performGroupedBlockAndWait {
             
             // GIVEN
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo", conversation: self.oneToOneConversation)
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            let confirmationMessage = self.oneToOneConversation.appendClientMessage(with: ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: UUID(), type: .DELIVERED)))!
             self.syncMOC.saveOrRollback()
-            guard let confirmationMessage = self.lastConfirmationMessage else { return XCTFail() }
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
             
             // WHEN
@@ -65,10 +46,8 @@ extension ClientMessageTranscoderTests {
         syncMOC.performGroupedBlockAndWait {
 
             // Given
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo", conversation: self.oneToOneConversation)
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            let confirmationMessage = self.oneToOneConversation.appendClientMessage(with: ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: UUID(), type: .DELIVERED)))!
             self.syncMOC.saveOrRollback()
-            guard let confirmationMessage = self.lastConfirmationMessage else { return XCTFail() }
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
 
             // When
@@ -87,204 +66,27 @@ extension ClientMessageTranscoderTests {
             XCTAssertTrue(message.hasConfirmation())
         }
     }
-    
+
     func testThatItDeletesTheConfirmationMessageWhenSentSuccessfully() {
-        
+
         // GIVEN
         var confirmationMessage: ZMMessage!
         self.syncMOC.performGroupedBlockAndWait {
-            
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo", conversation: self.oneToOneConversation)            
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+
+            confirmationMessage = self.oneToOneConversation.appendClientMessage(with: ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: UUID(), type: .DELIVERED)))
             self.syncMOC.saveOrRollback()
-            guard let confirmMessage = self.lastConfirmationMessage else { return XCTFail() }
-            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmMessage])) }
-            confirmationMessage = confirmMessage
-            
+            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
+
             // WHEN
             guard let request = self.sut.nextRequest() else { return XCTFail() }
             request.complete(with: ZMTransportResponse(payload: NSDictionary(), httpStatus: 200, transportSessionError: nil))
         }
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-            
+
         // THEN
         self.syncMOC.performGroupedBlockAndWait {
             XCTAssertTrue(confirmationMessage.isZombieObject)
         }
     }
-
-    func testThatItDoesSyncAConfirmationMessageIfSenderUserIsNotSpecifiedButIsInferedWithConntection() {
-        
-        self.syncMOC.performGroupedBlockAndWait {
-
-            // GIVEN
-            // receive message
-            let text = "This is the message!"
-            let event = self.decryptedUpdateEventFromOtherClient(text: text, conversation: self.oneToOneConversation)
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            self.syncMOC.saveOrRollback()
-            
-            guard let confirmMessage = self.lastConfirmationMessage else { return XCTFail() }
-            guard let originalMessage = self.oneToOneConversation.lastMessage as? ZMClientMessage else { return XCTFail() }
-            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmMessage])) }
-            
-            // WHEN
-            // remove sender
-            originalMessage.sender = nil
-            self.syncMOC.saveOrRollback()
-            guard let request = self.sut.nextRequest() else { return XCTFail() }
-            
-            // THEN
-            guard let message = self.outgoingEncryptedMessage(from: request, for: self.otherClient) else { return XCTFail() }
-            XCTAssertTrue(message.hasConfirmation())
-        }
-    }
     
-    func testThatItDoesSyncAConfirmationMessageIfSenderUserAndConnectIsNotSpecifiedButIsWithConversation() {
-        
-        self.syncMOC.performGroupedBlockAndWait {
-            
-            // GIVEN
-            // receive message
-            let text = "This is the message!"
-            let event = self.decryptedUpdateEventFromOtherClient(text: text, conversation: self.oneToOneConversation)
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            self.syncMOC.saveOrRollback()
-            
-            // find confirmation
-            guard let confirmMessage = self.lastConfirmationMessage else { return XCTFail() }
-            guard let originalMessage = self.oneToOneConversation.lastMessage as? ZMClientMessage else { return XCTFail() }
-            guard originalMessage.textMessageData?.messageText == text else { return XCTFail("wrong message?") }
-            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmMessage])) }
-            
-            // WHEN
-            // remove sender and connection
-            self.oneToOneConversation.connection = nil
-            originalMessage.sender = nil
-            self.syncMOC.saveOrRollback()
-            guard let request = self.sut.nextRequest() else { return XCTFail() }
-            
-            // THEN
-            guard let message = self.outgoingEncryptedMessage(from: request, for: self.otherClient) else { return XCTFail() }
-            XCTAssertTrue(message.hasConfirmation())
-        }
-    }
-    
-    func testThatItDoesNotSyncAConfirmationMessageIfCannotInferUser() {
-        self.syncMOC.performGroupedBlockAndWait {
-            
-            // GIVEN
-            // receive message
-            let text = "This is the message!"
-            let event = self.decryptedUpdateEventFromOtherClient(text: text, conversation: self.oneToOneConversation)
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            self.syncMOC.saveOrRollback()
-            
-            // find confirmation
-            guard let confirmMessage = self.lastConfirmationMessage else { return XCTFail() }
-            guard let originalMessage = self.oneToOneConversation.lastMessage as? ZMClientMessage else { return XCTFail() }
-            guard originalMessage.textMessageData?.messageText == text else { return XCTFail("wrong message?") }
-            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmMessage])) }
-            
-            // WHEN
-            // remove sender and connection
-            self.oneToOneConversation.connection = nil
-            originalMessage.sender = nil
-            self.oneToOneConversation.mutableLastServerSyncedActiveParticipants.removeAllObjects()
-            self.syncMOC.saveOrRollback()
-            
-            // THEN
-            XCTAssertNil(self.sut.nextRequest())
-        }
-    }
-    
-    func testThatItCallsConfirmationStatusWhenReceivingAnEventThroughPush() {
-        self.syncMOC.performGroupedBlockAndWait {
-            
-            // GIVEN
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo",
-                                                                 conversation: self.oneToOneConversation,
-                                                                 source: .pushNotification)
-            
-            // WHEN
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            
-            // THEN
-            guard let confirmMessage = self.lastConfirmationMessage else { return XCTFail() }
-            XCTAssertTrue(self.mockApplicationStatus.mockConfirmationStatus.messagesToConfirm.contains(confirmMessage.nonce!))
-        }
-    }
-    
-    func testThatItDoesNotCallsConfirmationStatusWhenReceivingAnEventThroughWebSocket() {
-        self.syncMOC.performGroupedBlockAndWait {
-            
-            // GIVEN
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo",
-                                                                 conversation: self.oneToOneConversation,
-                                                                 source: .webSocket)
-            
-            // WHEN
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            
-            // THEN
-            guard let confirmMessage = self.lastConfirmationMessage else { return XCTFail() }
-            XCTAssertFalse(self.mockApplicationStatus.mockConfirmationStatus.messagesToConfirm.contains(confirmMessage.nonce!))
-        }
-    }
-    
-    func testThatItDoesNotCallsConfirmationStatusWhenReceivingAnEventThroughDownload() {
-        self.syncMOC.performGroupedBlockAndWait {
-            
-            // GIVEN
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo",
-                                                                 conversation: self.oneToOneConversation,
-                                                                 source: .download)
-            
-            // WHEN
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            
-            // THEN
-            guard let confirmMessage = self.lastConfirmationMessage else { return XCTFail() }
-            XCTAssertFalse(self.mockApplicationStatus.mockConfirmationStatus.messagesToConfirm.contains(confirmMessage.nonce!))
-            XCTAssertFalse(self.mockApplicationStatus.mockConfirmationStatus.messagesConfirmed.contains(confirmMessage.nonce!))
-        }
-    }
-    
-    func testThatItCallsConfirmationStatusWhenConfirmationMessageIsSentSuccessfully() {
-        var confirmationNonce: UUID!
-        self.syncMOC.performGroupedBlockAndWait {
-            
-            // GIVEN
-            let event = self.decryptedUpdateEventFromOtherClient(text: "foo", conversation: self.oneToOneConversation)
-            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
-            self.syncMOC.saveOrRollback()
-            guard let confirmationMessage = self.lastConfirmationMessage else { return XCTFail() }
-            confirmationNonce = confirmationMessage.nonce!
-            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
-            
-            // WHEN
-            guard let request = self.sut.nextRequest() else { return XCTFail() }
-            request.complete(with: ZMTransportResponse(payload: NSDictionary(), httpStatus: 200, transportSessionError: nil))
-        }
-        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        // THEN
-        self.syncMOC.performGroupedBlockAndWait {
-            XCTAssertTrue(self.mockApplicationStatus.mockConfirmationStatus.messagesConfirmed.contains(confirmationNonce))
-        }
-    }
-
 }
-
-// MARK: - Helpers
-extension ClientMessageTranscoderTests {
-    
-    /// Last confirmation message in the one to one conversation
-    var lastConfirmationMessage: ZMClientMessage? {
-        return self.oneToOneConversation.hiddenMessages.first(where: {
-            guard let clientMessage = $0 as? ZMClientMessage else { return false }
-            return clientMessage.genericMessage!.hasConfirmation()
-        }) as? ZMClientMessage
-    }
-}
-


### PR DESCRIPTION
## What's new in this PR?

### Issues

We would send out multiple message delivery confirmations for incoming messages.

### Causes

We recently implemented support for confirming message delivery in batches after all events have been processed but didn't remove the old message delivery confirming code in the `ClientMessageTranscoder`.

### Solutions

Remove the now obsolete code for confirming message deliveries in `ClientMessageTranscoder` and update the tests.

## Notes

Since we no longer access any properties on  `ZMMessageUpdateResult in `ClientMessageTranscoder ` we simplify this API and return a ` ZMOTRMessage` . This will come in a separate PR.