### PR TITLE
Crash on verifying legal hold

### DIFF
--- a/Sources/Protocols/OTREntity.swift
+++ b/Sources/Protocols/OTREntity.swift
@@ -58,6 +58,7 @@ private let UnknownClientLabel = "unknown-client"
 /// Error label
 private let ErrorLabel = "label"
 
+
 extension OTREntity {
     
     /// Which object this message depends on when sending
@@ -131,9 +132,9 @@ extension OTREntity {
         var allMissingClients: Set<UserClient> = []
 
         for (userID, remoteClientIdentifiers) in missingMap {
-            guard let userID = UUID(uuidString: userID) else { continue }
-            let user = ZMUser(remoteID: userID, createIfNeeded: true, in: self.context)!
-
+            guard let userID = UUID(uuidString: userID),
+                  let user = ZMUser(remoteID: userID, createIfNeeded: true, in: self.context), !user.isSelfUser else { continue }
+            
             let remoteIdentifiers = Set(remoteClientIdentifiers)
             let localIdentifiers = Set(user.clients.compactMap(\.remoteIdentifier))
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would crash when force unwrapping the longer existing self client.

### Causes

The self client is never including the list of missing clients and was therefore deleted.

### Solutions

Exclude self clients when parsing the empty message response since we will receive these updates through other events.