### PR TITLE
[Fix] Retry download asset when Cloud server error is 403.

### DIFF
--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
@@ -107,7 +107,7 @@ fileprivate let zmLog = ZMSLog(tag: "Asset V3")
         if response.result == .success {
             downloadSuccess = storeAndDecrypt(data: response.rawData!, for: assetClientMessage)
         }
-        // When the beck end redirects to the cloud service to get the image, it could be that the network bandwidth of the device is really rare. If the time interval is pretty long before the connectivity returns good the cloud responds with an error having status code 403 -> retry the image request and not delete the asset client message.
+        // When the backend redirects to the cloud service to get the image, it could be that the network bandwidth of the device is really bad. If the time interval is pretty long before the connectivity returns, the cloud responds with an error having status code 403 -> retry the image request and do not delete the asset client message.
         else if response.result == .permanentError, response.httpStatus != 403 {
             zmLog.debug("asset unavailable on remote (\(response.httpStatus)), deleting")
             managedObjectContext.delete(assetClientMessage)

--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
@@ -107,7 +107,10 @@ fileprivate let zmLog = ZMSLog(tag: "Asset V3")
         if response.result == .success {
             downloadSuccess = storeAndDecrypt(data: response.rawData!, for: assetClientMessage)
         }
-        // When the backend redirects to the cloud service to get the image, it could be that the network bandwidth of the device is really bad. If the time interval is pretty long before the connectivity returns, the cloud responds with an error having status code 403 -> retry the image request and do not delete the asset client message.
+//        When the backend redirects to the cloud service to get the image, it could be that the
+//        network bandwidth of the device is really bad. If the time interval is pretty long before
+//        the connectivity returns, the cloud responds with an error having status code 403
+//        -> retry the image request and do not delete the asset client message.
         else if response.result == .permanentError, response.httpStatus != 403 {
             zmLog.debug("asset unavailable on remote (\(response.httpStatus)), deleting")
             managedObjectContext.delete(assetClientMessage)

--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
@@ -294,7 +294,7 @@ extension AssetV3DownloadRequestStrategyTests {
         }
     }
 
-    // When the beck end redirects to the cloud service to get the image, it could be that the network bandwidth of the device is really rare. If the time interval is pretty long before the connectivity returns good the cloud responds with an error having status code 403.
+    // When the backend redirects to the cloud service to get the image, it could be that the network bandwidth of the device is really bad. If the time interval is pretty long before the connectivity returns, the cloud responds with an error having status code 403 -> retry the image request and do not delete the asset client message.
     func testThatItMarksDownloadAsFailedIfCannotDownload_TemporaryError_403_V3() {
         let message: ZMAssetClientMessage = syncMOC.performGroupedAndWait { _ in
             // GIVEN

--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
@@ -294,7 +294,10 @@ extension AssetV3DownloadRequestStrategyTests {
         }
     }
 
-    // When the backend redirects to the cloud service to get the image, it could be that the network bandwidth of the device is really bad. If the time interval is pretty long before the connectivity returns, the cloud responds with an error having status code 403 -> retry the image request and do not delete the asset client message.
+//        When the backend redirects to the cloud service to get the image, it could be that the
+//        network bandwidth of the device is really bad. If the time interval is pretty long before
+//        the connectivity returns, the cloud responds with an error having status code 403
+//        -> retry the image request and do not delete the asset client message.
     func testThatItMarksDownloadAsFailedIfCannotDownload_TemporaryError_403_V3() {
         let message: ZMAssetClientMessage = syncMOC.performGroupedAndWait { _ in
             // GIVEN


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR solve the following edge case: when the back end redirects to the cloud service to get the image asset in a conversation, it could happen that the network bandwidth of the device is really rare. If the time interval is pretty long before the connectivity returns good the cloud responds with an error having status code 403

### Solutions

retry the image request and not delete the asset client message in case of status code 403.