### PR TITLE
[Fix] Always communicate status

### DIFF
--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
@@ -31,21 +31,11 @@ public class AvailabilityRequestStrategy: AbstractRequestStrategy {
         self.modifiedSync = ZMUpstreamModifiedObjectSync(transcoder: self,
                                                          entityName: ZMUser.entityName(),
                                                          update: nil,
-                                                         filter: predicateForSelfUserCommunicatingStatus(),
+                                                         filter: ZMUser.predicateForSelfUser(),
                                                          keysToSync: [AvailabilityKey],
                                                          managedObjectContext: managedObjectContext)
     }
-    
-    private func predicateForSelfUserCommunicatingStatus() -> NSPredicate {
-        let statusPredicate =  NSPredicate { object, _ in
-            guard let user = object as? ZMUser else { return false }
-            return user.team?.shouldCommunicateStatus ?? true
-        }
-        let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [statusPredicate, ZMUser.predicateForSelfUser()])
-        
-        return compoundPredicate
-    }
-    
+
     public override func nextRequestIfAllowed() -> ZMTransportRequest? {
         return modifiedSync.nextRequest()
     }

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
@@ -60,33 +60,6 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
         }
     }
     
-    func testThatItDoesntGenerateARequestWhenAvailabilityIsModifiedAndGuestShouldntCommunicateStatus() {
-        self.syncMOC.performGroupedAndWait { moc in
-            
-            // given
-            let selfUser = ZMUser.selfUser(in: moc)
-            selfUser.needsToBeUpdatedFromBackend = false
-            selfUser.setLocallyModifiedKeys(Set(arrayLiteral: AvailabilityKey))
-            
-            let team = Team.insertNewObject(in: moc)
-            for _ in 1...(Team.membersOptimalLimit - 1) { // Saving one user to add selfuser later on
-                team.members.insert(Member.insertNewObject(in: moc))
-            }
-            
-            let membership = Member.insertNewObject(in: moc)
-            membership.user = selfUser
-            membership.team = team
-            
-            self.sut.contextChangeTrackers.forEach({ $0.addTrackedObjects(Set<NSManagedObject>(arrayLiteral: selfUser)) })
-            
-            // when
-            let request = self.sut.nextRequest()
-            
-            // then
-            XCTAssertNil(request)
-        }
-    }
-    
     func testThatItGeneratesARequestWhenAvailabilityIsModifiedAndGuestShouldCommunicateStatus() {
         self.syncMOC.performGroupedAndWait { moc in
             
@@ -96,10 +69,7 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
             selfUser.setLocallyModifiedKeys(Set(arrayLiteral: AvailabilityKey))
             
             let team = Team.insertNewObject(in: moc)
-            for _ in 1...(Team.membersOptimalLimit - 2) { // Saving one user to add selfuser later on
-                team.members.insert(Member.insertNewObject(in: moc))
-            }
-            
+          
             let membership = Member.insertNewObject(in: moc)
             membership.user = selfUser
             membership.team = team


### PR DESCRIPTION
## What's new in this PR?

### Issues

Currently we are not sending status updates if the team is above a certain size. This is direct conflict with the new status broadcast strategy, where we ensure status updates are sent to a specified maximum number of recipients.

### Solutions

Remove the code related to where the status should be communicated.

### Dependencies

- [x] https://github.com/wireapp/wire-ios-data-model/pull/942

### Attachments

**JIRA:** https://wearezeta.atlassian.net/browse/ZIOS-12885