### PR TITLE
[Fix] Don't mark clients with established sessions as missed

### DIFF
--- a/Sources/Protocols/OTREntity.swift
+++ b/Sources/Protocols/OTREntity.swift
@@ -270,8 +270,14 @@ extension OTREntity {
             
             // client
             guard let clientIDs = pair.1 as? [String] else { fatal("Missing client ID is not parsed properly") }
-            let clients: [UserClient] = clientIDs.map {
-                let client = UserClient.fetchUserClient(withRemoteId: $0, forUser: user, createIfNeeded: true)!
+            let clients: [UserClient] = clientIDs.compactMap {
+                guard
+                    let client = UserClient.fetchUserClient(withRemoteId: $0, forUser: user, createIfNeeded: true),
+                    !client.hasSessionWithSelfClient
+                else {
+                    return nil
+                }
+                
                 client.discoveredByMessage = self as? ZMOTRMessage
                 return client
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We had an incident (internal) were encryption sessions broke, which resulted in decryption errors.

### Causes

The session broke because the backend unexpectedly reported client as missing when they weren't due to mismatch between backend and client rollout. We the client was blindly trusting the server that client were missing and re-fetched the pre-keys and established new sessions, effectively breaking the sessions.

Even though this shouldn't happen when the client and backend is in sync but it still would  be nice to be resilient towards these kind of issues.

### Solutions

Verify that a client doesn't already have an established session before adding it to the list of missing clients.