### PR TITLE
[Feature] re-fetch redundant users in order to discover if they are deleted

### DIFF
--- a/Sources/Helpers/ZMMessage+Dependency.swift
+++ b/Sources/Helpers/ZMMessage+Dependency.swift
@@ -37,11 +37,15 @@ extension ZMOTRMessage: OTREntity {
         return dependent ?? super.dependentObjectNeedingUpdateBeforeProcessing
     }
     
-    public func detectedRedundantClients() {
+    public func detectedRedundantUsers(_ users: [ZMUser]) {
         // if the BE tells us that these users are not in the
         // conversation anymore, it means that we are out of sync
         // with the list of participants
         conversation?.needsToBeUpdatedFromBackend = true
+        
+        // The missing users might have been deleted so we need re-fetch their profiles
+        // to verify if that's the case.
+        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
     }
     
     public func detectedMissingClient(for user: ZMUser) {

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
@@ -116,8 +116,11 @@ extension AvailabilityRequestStrategy: OTREntity {
     public func detectedRedundantUsers(_ users: [ZMUser]) {
         // We were sending a message to clients which should not receive it. To recover
         // from this we must restart the slow sync.
-        
         applicationStatus?.requestSlowSync()
+        
+        // The missing users might have been deleted so we need re-fetch their profiles
+        // to verify if that's the case.
+        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
     }
     
     public func detectedMissingClient(for user: ZMUser) {

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
@@ -113,7 +113,7 @@ extension AvailabilityRequestStrategy: OTREntity {
         // BE notified us about a new client. A session will be established and then we'll try again
     }
     
-    public func detectedRedundantClients() {
+    public func detectedRedundantUsers(_ users: [ZMUser]) {
         // We were sending a message to clients which should not receive it. To recover
         // from this we must restart the slow sync.
         

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
@@ -127,9 +127,12 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
     }
     
     func testThatItRequestSlowSyncIfWeAreSendingToRedudantClients() {
-        self.syncMOC.performGroupedAndWait { _ in
-            // given when
-            self.sut.detectedRedundantClients()
+        self.syncMOC.performGroupedAndWait { moc in
+            // given
+            let redundantUser = ZMUser(remoteID: UUID(), createIfNeeded: true, in: moc)!
+            
+            // when
+            self.sut.detectedRedundantUsers([redundantUser])
 
             // then
             XCTAssertTrue(self.applicationStatus.slowSyncWasRequested)

--- a/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
@@ -45,11 +45,15 @@ import Foundation
         // no-op
     }
     
-    public func detectedRedundantClients() {
+    public func detectedRedundantUsers(_ users: [ZMUser]) {
         // if the BE tells us that these users are not in the
         // conversation anymore, it means that we are out of sync
         // with the list of participants
         conversation?.needsToBeUpdatedFromBackend = true
+        
+        // The missing users might have been deleted so we need re-fetch their profiles
+        // to verify if that's the case.
+        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
     }
     
     public func detectedMissingClient(for user: ZMUser) {

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -106,8 +106,12 @@ fileprivate class VerifyClientsParser: OTREntity {
         // no-op
     }
     
-    func detectedRedundantClients() {
+    func detectedRedundantUsers(_ users: [ZMUser]) {
         conversation.needsToBeUpdatedFromBackend = true
+        
+        // The missing users might have been deleted so we need re-fetch their profiles
+        // to verify if that's the case.
+        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
     }
     
     func detectedMissingClient(for user: ZMUser) {


### PR DESCRIPTION
## What's new in this PR?

We already re-fetch user metadata when we discover that the last client of user is deleted when sending a message. In addition to that we also need to re-fetch the metadata when a user is reported as redundant when sending a message. 

Being redundant means that the user is no longer part of the conversation, which could mean that the user left the conversation and you missed the leave event or that the user has deleted his account and you missed the user deletion event. In either case we resolve it by re-fetching the conversation and the user metadata.

## Notes

There's quite some code duplication going on here but fixing it would be too big of a task include in this PR. I'll create a separate re-factoring ticket for this.