### PR TITLE
[Refactor] Remove code duplication when processing message sending responses

### DIFF
--- a/Sources/Helpers/ZMMessage+Dependency.swift
+++ b/Sources/Helpers/ZMMessage+Dependency.swift
@@ -41,10 +41,6 @@ extension ZMOTRMessage: OTREntity {
         // no-op
     }
     
-    public func detectedMissingClient(for user: ZMUser) {
-        // no-op
-    }
-    
 }
 
 /// Message that can block following messages

--- a/Sources/Helpers/ZMMessage+Dependency.swift
+++ b/Sources/Helpers/ZMMessage+Dependency.swift
@@ -38,18 +38,11 @@ extension ZMOTRMessage: OTREntity {
     }
     
     public func detectedRedundantUsers(_ users: [ZMUser]) {
-        // if the BE tells us that these users are not in the
-        // conversation anymore, it means that we are out of sync
-        // with the list of participants
-        conversation?.needsToBeUpdatedFromBackend = true
-        
-        // The missing users might have been deleted so we need re-fetch their profiles
-        // to verify if that's the case.
-        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
+        // no-op
     }
     
     public func detectedMissingClient(for user: ZMUser) {
-        conversation?.addParticipantAndSystemMessageIfMissing(user, date: nil)
+        // no-op
     }
     
 }

--- a/Sources/Protocols/OTREntity.swift
+++ b/Sources/Protocols/OTREntity.swift
@@ -40,9 +40,6 @@ private let zmLog = ZMSLog(tag: "Dependencies")
     /// with the list of participants
     func detectedRedundantUsers(_ users: [ZMUser])
     
-    /// This method is called when BE doesn't find clients
-    /// in the uploaded payload.
-    func detectedMissingClient(for user: ZMUser)
 }
 
 /// HTTP status of a request that has
@@ -170,7 +167,6 @@ extension OTREntity {
             }
 
             if !userMissingClients.isEmpty {
-                detectedMissingClient(for: user)
                 allMissingClients.formUnion(userMissingClients)
             }
         }
@@ -318,7 +314,6 @@ extension OTREntity {
             
             // is this user not there?
             conversation?.addParticipantAndSystemMessageIfMissing(user, date: nil)
-            detectedMissingClient(for: user)
             
             return clients
         })

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
@@ -122,12 +122,7 @@ extension AvailabilityRequestStrategy: OTREntity {
         // from this we must restart the slow sync.
         applicationStatus?.requestSlowSync()
     }
-    
-    public func detectedMissingClient(for user: ZMUser) {
-        // Broadcast messsages are targeted to specific set of recipients and we will ignore any other
-        // users who are not recipients.
-    }
-    
+        
     public var dependentObjectNeedingUpdateBeforeProcessing: NSObject? {
         let recipients = ZMUser.recipientsForAvailabilityStatusBroadcast(in: context, maxCount: maximumBroadcastRecipients)
         return self.dependentObjectNeedingUpdateBeforeProcessingOTREntity(recipients: recipients)

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
@@ -104,9 +104,13 @@ extension AvailabilityRequestStrategy: ZMUpstreamTranscoder {
 }
 
 extension AvailabilityRequestStrategy: OTREntity {
-    
+
     public var context: NSManagedObjectContext {
         return managedObjectContext
+    }
+    
+    public var conversation: ZMConversation? {
+        return nil
     }
     
     public func missesRecipients(_ recipients: Set<UserClient>!) {
@@ -117,10 +121,6 @@ extension AvailabilityRequestStrategy: OTREntity {
         // We were sending a message to clients which should not receive it. To recover
         // from this we must restart the slow sync.
         applicationStatus?.requestSlowSync()
-        
-        // The missing users might have been deleted so we need re-fetch their profiles
-        // to verify if that's the case.
-        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
     }
     
     public func detectedMissingClient(for user: ZMUser) {

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
@@ -139,30 +139,4 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
         }
     }
     
-    func testThatItDoesNotRequestSlowSyncIfWeAreMissingAUser() {
-        self.syncMOC.performGroupedAndWait { moc in
-            // given
-            let missingUser = ZMUser(remoteID: UUID(), createIfNeeded: true, in: moc)!
-
-            // when
-            self.sut.detectedMissingClient(for: missingUser)
-
-            // then
-            XCTAssertFalse(self.applicationStatus.slowSyncWasRequested)
-        }
-    }
-    
-    func testThatItDoesNotRequestSlowSyncIfWeAreNotMissingAUser() {
-        self.syncMOC.performGroupedAndWait { _ in
-            // given
-            let connectedUser = self.otherUser!
-
-            // when
-            self.sut.detectedMissingClient(for: connectedUser)
-
-            // then
-            XCTAssertFalse(self.applicationStatus.slowSyncWasRequested)
-        }
-    }
-    
 }

--- a/Sources/Request Strategies/Base Strategies/OTREntityTranscoderTests.swift
+++ b/Sources/Request Strategies/Base Strategies/OTREntityTranscoderTests.swift
@@ -51,11 +51,7 @@ import XCTest
     func detectedRedundantUsers(_ users: [ZMUser]) {
         // no-op
     }
-    
-    func detectedMissingClient(for user: ZMUser) {
-        // no-op
-    }
-    
+        
 }
 
 func ==(lhs: MockOTREntity, rhs: MockOTREntity) -> Bool {

--- a/Sources/Request Strategies/Base Strategies/OTREntityTranscoderTests.swift
+++ b/Sources/Request Strategies/Base Strategies/OTREntityTranscoderTests.swift
@@ -49,18 +49,11 @@ import XCTest
     }
     
     func detectedRedundantUsers(_ users: [ZMUser]) {
-        // if the BE tells us that these users are not in the
-        // conversation anymore, it means that we are out of sync
-        // with the list of participants
-        conversation?.needsToBeUpdatedFromBackend = true
-        
-        // The missing users might have been deleted so we need re-fetch their profiles
-        // to verify if that's the case.
-        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
+        // no-op
     }
     
     func detectedMissingClient(for user: ZMUser) {
-        conversation?.addParticipantAndSystemMessageIfMissing(user, date: nil)
+        // no-op
     }
     
 }

--- a/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
@@ -48,11 +48,7 @@ import Foundation
     public func detectedRedundantUsers(_ users: [ZMUser]) {
         // no-op
     }
-    
-    public func detectedMissingClient(for user: ZMUser) {
-        // no-op
-    }
-    
+        
     public func expire() {
         isExpired = true
     }

--- a/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
@@ -46,18 +46,11 @@ import Foundation
     }
     
     public func detectedRedundantUsers(_ users: [ZMUser]) {
-        // if the BE tells us that these users are not in the
-        // conversation anymore, it means that we are out of sync
-        // with the list of participants
-        conversation?.needsToBeUpdatedFromBackend = true
-        
-        // The missing users might have been deleted so we need re-fetch their profiles
-        // to verify if that's the case.
-        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
+        // no-op
     }
     
     public func detectedMissingClient(for user: ZMUser) {
-        conversation?.addParticipantAndSystemMessageIfMissing(user, date: nil)
+        // no-op
     }
     
     public func expire() {

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -109,11 +109,7 @@ fileprivate class VerifyClientsParser: OTREntity {
     func detectedRedundantUsers(_ users: [ZMUser]) {
         // no-op
     }
-    
-    func detectedMissingClient(for user: ZMUser) {
-        // no-op
-    }
-    
+        
     var dependentObjectNeedingUpdateBeforeProcessing: NSObject? = nil
     
     var isExpired: Bool = false

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -95,7 +95,7 @@ extension VerifyLegalHoldRequestStrategy: IdentifierObjectSyncTranscoder {
 fileprivate class VerifyClientsParser: OTREntity {
     
     var context: NSManagedObjectContext
-    let conversation: ZMConversation
+    let conversation: ZMConversation?
     
     init(context: NSManagedObjectContext, conversation: ZMConversation) {
         self.context = context
@@ -107,11 +107,7 @@ fileprivate class VerifyClientsParser: OTREntity {
     }
     
     func detectedRedundantUsers(_ users: [ZMUser]) {
-        conversation.needsToBeUpdatedFromBackend = true
-        
-        // The missing users might have been deleted so we need re-fetch their profiles
-        // to verify if that's the case.
-        users.forEach({ $0.needsToBeUpdatedFromBackend = true })
+        // no-op
     }
     
     func detectedMissingClient(for user: ZMUser) {


### PR DESCRIPTION
## What's new in this PR?

This is a follow up on https://github.com/wireapp/wire-ios-request-strategy/pull/220 to remove some code duplication.

### Issues

Parts of the business logic for handling redundant and missing clients was duplicated in all the objects implementing the `OTREntity` protocol

### Solutions

Add an optional `conversation: ZMConversation?` property to the`OTREntity` protocol and move the duplicated business logic into the protocol methods for parsing redundant and missing clients.