### PR TITLE
[Feature] Client discovery strategy

### DIFF
--- a/Sources/Request Strategies/User Clients/ClientDiscoveryRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/ClientDiscoveryRequestStrategy.swift
@@ -24,7 +24,7 @@ import Foundation
 public final class ClientDiscoveryRequestStrategy: NSObject, RequestStrategy {
 
   public typealias ClientIdsByUserId = [String: [String]]
-  public typealias ClientDiscoveryRequestCompletion = (ClientIdsByUserId) -> Void
+  public typealias RequestCompletion = (ClientIdsByUserId) -> Void
 
   // MARK: - Private properties
 
@@ -34,7 +34,7 @@ public final class ClientDiscoveryRequestStrategy: NSObject, RequestStrategy {
   private var requestSync: ZMSingleRequestSync!
 
   private var pendingRequest: ZMTransportRequest?
-  private var pendingCompletion: ClientDiscoveryRequestCompletion?
+  private var pendingCompletion: RequestCompletion?
 
   // MARK: - Init
 
@@ -56,7 +56,7 @@ public final class ClientDiscoveryRequestStrategy: NSObject, RequestStrategy {
   ///   - conversationId: the id of the conversation.
   ///   - completion: invoked with a map of user ids to an array of client ids.
 
-  public func requestClientList(conversationId: UUID, completion: @escaping ClientDiscoveryRequestCompletion) {
+  public func requestClientList(conversationId: UUID, completion: @escaping RequestCompletion) {
     managedObjectContext.performGroupedBlock { [unowned self] in
       guard let selfClient = ZMUser.selfUser(in: self.managedObjectContext).selfClient() else { return }
 

--- a/Sources/Request Strategies/User Clients/ClientDiscoveryRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/ClientDiscoveryRequestStrategy.swift
@@ -1,0 +1,92 @@
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+
+import Foundation
+
+/// This strategy is used to get an up-to-date list of all clients in a given conversation.
+/// It achieves this by posting an empty OTR message with no recipients in the coversation,
+/// then parsing the 412 error response to discover the list of missing clients reported by
+/// the backend.
+
+public final class ClientDiscoveryRequestStrategy: NSObject, RequestStrategy {
+
+  public typealias ClientIdsByUserId = [String: [String]]
+  public typealias ClientDiscoveryRequestCompletion = (ClientIdsByUserId) -> Void
+
+  // MARK: - Private properties
+
+  private let managedObjectContext: NSManagedObjectContext
+
+  private let requestFactory = ClientMessageRequestFactory()
+  private var requestSync: ZMSingleRequestSync!
+
+  private var pendingRequest: ZMTransportRequest?
+  private var pendingCompletion: ClientDiscoveryRequestCompletion?
+
+  // MARK: - Init
+
+  public init(withManagedObjectContext managedObjectContext: NSManagedObjectContext) {
+    self.managedObjectContext = managedObjectContext
+    super.init()
+    requestSync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: managedObjectContext)
+  }
+
+  // MARK: - Methods
+
+  public func nextRequest() -> ZMTransportRequest? {
+    return requestSync.nextRequest()
+  }
+
+  /// Triggers a request to fetch the list of clients in a given conversation.
+  ///
+  /// - Parameters:
+  ///   - conversationId: the id of the conversation.
+  ///   - completion: invoked with a map of user ids to an array of client ids.
+
+  public func requestClientList(conversationId: UUID, completion: @escaping ClientDiscoveryRequestCompletion) {
+    managedObjectContext.performGroupedBlock { [unowned self] in
+      guard let selfClient = ZMUser.selfUser(in: self.managedObjectContext).selfClient() else { return }
+
+      self.pendingRequest = self.requestFactory.upstreamRequestForFetchingClients(conversationId: conversationId,
+                                                                                  selfClient: selfClient)
+      self.pendingCompletion = completion
+      self.requestSync.readyForNextRequestIfNotBusy()
+      RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+    }
+  }
+
+}
+
+// MARK: - Single Request Transcoder
+
+extension ClientDiscoveryRequestStrategy: ZMSingleRequestTranscoder {
+
+  public func request(for sync: ZMSingleRequestSync) -> ZMTransportRequest? {
+    defer { pendingRequest = nil }
+    return pendingRequest
+  }
+
+  public func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
+    guard
+      let payload = response.payload as? [String: AnyObject],
+      let missingClients = payload["missing"] as? ClientIdsByUserId
+      else { return }
+
+    pendingCompletion?(missingClients)
+    pendingCompletion = nil
+  }
+
+}

--- a/Sources/Request Strategies/User Clients/ClientDiscoveryRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/ClientDiscoveryRequestStrategyTests.swift
@@ -1,0 +1,100 @@
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireRequestStrategy
+
+class ClientDiscoveryRequestStrategyTests: MessagingTestBase {
+
+  // MARK: - Properties
+
+  var sut: ClientDiscoveryRequestStrategy!
+  var mockApplicationStatus: MockApplicationStatus!
+
+  // MARK: - Configuration
+
+  override func setUp() {
+    super.setUp()
+    mockApplicationStatus = MockApplicationStatus()
+    mockApplicationStatus.mockSynchronizationState = .eventProcessing
+    sut = ClientDiscoveryRequestStrategy(withManagedObjectContext: syncMOC)
+  }
+
+  override func tearDown() {
+    mockApplicationStatus = nil
+    sut = nil
+    super.tearDown()
+  }
+
+  // MARK: - Tests
+
+  func testThatItCreatesTheRequest() {
+    var conversationId: UUID!
+
+    syncMOC.performGroupedBlockAndWait {
+      // Given
+      conversationId = self.groupConversation.remoteIdentifier!
+
+      // When
+      self.sut.requestClientList(conversationId: conversationId) { _ in }
+    }
+
+    XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+    // Then
+    let request = sut.nextRequest()
+    XCTAssertEqual(request?.path, "/conversations/\(conversationId.transportString())/otr/messages")
+  }
+
+  func testInvokesCompletionHandler() {
+    var conversationId: UUID!
+    let completionInvoked = XCTestExpectation(description: "completion invoked")
+
+    syncMOC.performGroupedBlockAndWait {
+      // Given
+      conversationId = self.groupConversation.remoteIdentifier!
+
+      // When
+      self.sut.requestClientList(conversationId: conversationId) { missingClientsMap in
+        let expectedClientsMap = [
+          "user1": ["client1", "client2"],
+          "user2": ["client1"]
+        ]
+
+        // Then
+        XCTAssertEqual(missingClientsMap, expectedClientsMap)
+        completionInvoked.fulfill()
+      }
+    }
+
+    XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+    let request = sut.nextRequest()
+
+    let payload = [
+      "missing": [
+        "user1": ["client1", "client2"],
+        "user2": ["client1"]
+      ]
+    ]
+
+    request?.complete(with: ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 412, transportSessionError: nil))
+    wait(for: [completionInvoked], timeout: 0.5)
+  }
+
+}

--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		BFF9446620F5F79F00531BC3 /* ImageV2DownloadRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF9446520F5F79F00531BC3 /* ImageV2DownloadRequestStrategyTests.swift */; };
 		D5D65A062073C8F800D7F3C3 /* AssetRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D65A052073C8F800D7F3C3 /* AssetRequestFactoryTests.swift */; };
 		D5D65A072074C23D00D7F3C3 /* AssetRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F963E8D91D955D4600098AD3 /* AssetRequestFactory.swift */; };
+		EE7334C7246D5BEB008640F9 /* ClientDiscoveryRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7334C6246D5BEB008640F9 /* ClientDiscoveryRequestStrategy.swift */; };
+		EE7334C9246D6892008640F9 /* ClientDiscoveryRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7334C8246D6892008640F9 /* ClientDiscoveryRequestStrategyTests.swift */; };
 		F13ADE7D21B5355F00B6E736 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F13ADE7C21B5355F00B6E736 /* SwiftProtobuf.framework */; };
 		F13ADE8021B5449400B6E736 /* SwiftProtobuf.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F13ADE7C21B5355F00B6E736 /* SwiftProtobuf.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F14B7AEA222009BA00458624 /* UserRichProfileRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */; };
@@ -346,6 +348,8 @@
 		BF6651321D8C2ED50074F367 /* ProtocolBuffers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ProtocolBuffers.framework; path = Carthage/Build/iOS/ProtocolBuffers.framework; sourceTree = "<group>"; };
 		BFF9446520F5F79F00531BC3 /* ImageV2DownloadRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageV2DownloadRequestStrategyTests.swift; sourceTree = "<group>"; };
 		D5D65A052073C8F800D7F3C3 /* AssetRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetRequestFactoryTests.swift; sourceTree = "<group>"; };
+		EE7334C6246D5BEB008640F9 /* ClientDiscoveryRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientDiscoveryRequestStrategy.swift; sourceTree = "<group>"; };
+		EE7334C8246D6892008640F9 /* ClientDiscoveryRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientDiscoveryRequestStrategyTests.swift; sourceTree = "<group>"; };
 		F13ADE7C21B5355F00B6E736 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftProtobuf.framework; path = Carthage/Build/iOS/SwiftProtobuf.framework; sourceTree = "<group>"; };
 		F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategy.swift; sourceTree = "<group>"; };
 		F14B7AEB222009C200458624 /* UserRichProfileRequestStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategyTests.swift; sourceTree = "<group>"; };
@@ -685,6 +689,8 @@
 				F18401622073BE0800E9F4CC /* MissingClientsRequestStrategyTests.swift */,
 				1662ADB222B0E8B300D84071 /* VerifyLegalHoldRequestStrategy.swift */,
 				1662ADD022B14CBA00D84071 /* VerifyLegalHoldRequestStrategyTests.swift */,
+				EE7334C6246D5BEB008640F9 /* ClientDiscoveryRequestStrategy.swift */,
+				EE7334C8246D6892008640F9 /* ClientDiscoveryRequestStrategyTests.swift */,
 			);
 			path = "User Clients";
 			sourceTree = "<group>";
@@ -1192,6 +1198,7 @@
 				16D0E07F1DF88B430075DF8F /* EntityTranscoder.swift in Sources */,
 				F18401A62073BE0800E9F4CC /* MissingClientsRequestStrategy.swift in Sources */,
 				166901DD1D7081C7000FE4AF /* ZMLocallyModifiedObjectSyncStatus.m in Sources */,
+				EE7334C7246D5BEB008640F9 /* ClientDiscoveryRequestStrategy.swift in Sources */,
 				F18401BB2073BE0800E9F4CC /* LinkPreviewAssetDownloadRequestStrategy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1250,6 +1257,7 @@
 				F18401F02073C26C00E9F4CC /* LinkPreviewAssetDownloadRequestStrategyTests.swift in Sources */,
 				F18401FF2073C2EA00E9F4CC /* MessagingTestBase.swift in Sources */,
 				F18401E62073C26200E9F4CC /* MissingClientsMapTests.swift in Sources */,
+				EE7334C9246D6892008640F9 /* ClientDiscoveryRequestStrategyTests.swift in Sources */,
 				F1956200202A141B005347C0 /* ZMDownstreamObjectSyncOrderingTests.m in Sources */,
 				5E9EA4E02243C6B200D401B2 /* LinkAttachmentsPreprocessorTests.swift in Sources */,
 				F18401EE2073C26C00E9F4CC /* LinkPreviewAssetUploadRequestStrategyTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

This PR introduces the `ClientDiscoveryRequestStrategy`, a strategy designed to fetch a list of all clients in a given conversation. This strategy is intended to be used to provide AVS with a client list for use with SFT calls.

It works by sending an OTR message with an empty payload and zero recipients in a specific conversation. The backend will return a 412 response indicating that the message is missing recipients (as expected). In the payload of the response we will find a list of all missing clients, which will be the list of all clients in the conversation. This list is then passed into a completion handler.

