### PR TITLE
[Fix] Remove unused ZMLinkPreview extension

### DIFF
--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategy.swift
@@ -140,15 +140,3 @@ extension LinkPreviewAssetDownloadRequestStrategy: ZMDownstreamTranscoder {
     }
     
 }
-
-extension ZMLinkPreview {
-    var remote: ZMAssetRemoteData? {
-        if let image = article.image, image.hasUploaded() {
-            return image.uploaded
-        } else if let image = image, hasImage() {
-            return image.uploaded
-        }
-        
-        return nil
-    }
-}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Unused `ZMLinkPreview` causes build error when objc protobufs are removed (using [this branch of wire-ios-protos](https://github.com/wireapp/wire-ios-protos/tree/refactor/remove-objc-message-proto))

### Solutions

Remove the extension since it is unused.
