### PR TITLE
[Fix] Don't schedule duplicate notifications

### DIFF
--- a/Sources/Protocols/PushMessageHandler.swift
+++ b/Sources/Protocols/PushMessageHandler.swift
@@ -20,13 +20,7 @@ import Foundation
 import WireDataModel
 
 @objc public protocol PushMessageHandler: NSObjectProtocol {
-    
-    /// Create a notification for the message if needed
-    ///
-    /// - Parameter event: the decrypted  ZMUpdateEvent 
-    @objc(processEvent:)
-    func process(_ event: ZMUpdateEvent)
-    
+        
     /// Shows a notification for a failure to send
     ///
     /// - Parameter message: message that failed to send

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
@@ -159,13 +159,7 @@ extension ClientMessageTranscoder {
     func insertMessage(from event: ZMUpdateEvent, prefetchResult: ZMFetchRequestBatchResult?) {
         switch event.type {
         case .conversationClientMessageAdd, .conversationOtrMessageAdd, .conversationOtrAssetAdd:
-            
-            // process generic message first, b/c if there is no updateResult, then
-            // a the event from a deleted message wouldn't delete the notification.
-            if event.source == .pushNotification || event.source == .webSocket {
-                self.localNotificationDispatcher.process(event)
-            }
-            
+                        
             guard let message = ZMOTRMessage.createOrUpdate(from: event, in: managedObjectContext, prefetchResult: prefetchResult) else { return }
             
             message.markAsSent()

--- a/Tests/Helpers/MockObjects.swift
+++ b/Tests/Helpers/MockObjects.swift
@@ -92,18 +92,6 @@ class MockPushMessageHandler: NSObject, PushMessageHandler {
     public func didFailToSend(_ message: ZMMessage) {
         failedToSend.append(message)
     }
-    
-    public func process(_ message: ZMMessage) {
-        processedMessages.append(message)
-    }
-    
-    public func process(_ event: ZMUpdateEvent) {
-        if let genericMessage = GenericMessage(from: event) {
-            processedGenericMessages.append(genericMessage)
-        }
-    }
-    
+        
     fileprivate(set) var failedToSend: [ZMMessage] = []
-    fileprivate(set) var processedMessages: [ZMMessage] = []
-    fileprivate(set) var processedGenericMessages: [GenericMessage] = []
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When receiving a message we are scheduling duplicate notifications for messages

### Causes

Since notifications for regular messages are now created directly from update events we should take care to only process events once otherwise we'll insert multiple notifications per message. This was happening in the `ClientMessageTranscoder` which forwarded all update events to notification dispatcher in order to cancel notifications for edited, deleted or hidden messages.

### Solutions

- Stop forward events to local notification dispatcher since this already happens in `ZMSyncStrategy+EventProcessing`
- Remove now no longer used method on the `PushMessageHandler` protocol