### PR TITLE
[Fix] Avoid sending encrypted messages while fetching the notification stream

### DIFF
--- a/Sources/Helpers/ZMStrategyConfigurationOption.h
+++ b/Sources/Helpers/ZMStrategyConfigurationOption.h
@@ -20,7 +20,8 @@ typedef NS_OPTIONS(NSUInteger, ZMStrategyConfigurationOption) {
     ZMStrategyConfigurationOptionDoesNotAllowRequests = 0,
     ZMStrategyConfigurationOptionAllowsRequestsWhileUnauthenticated = 1 << 0,
     ZMStrategyConfigurationOptionAllowsRequestsWhileInBackground = 1 << 1,
-    ZMStrategyConfigurationOptionAllowsRequestsDuringSync = 1 << 2,
-    ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing = 1 << 3,
-    ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch = 1 << 4
+    ZMStrategyConfigurationOptionAllowsRequestsWhileOnline = 1 << 4,
+    ZMStrategyConfigurationOptionAllowsRequestsDuringSlowSync = 1 << 2,
+    ZMStrategyConfigurationOptionAllowsRequestsDuringQuickSync = 1 << 3,
+    ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch = 1 << 5
 };

--- a/Sources/Helpers/ZMStrategyConfigurationOption.h
+++ b/Sources/Helpers/ZMStrategyConfigurationOption.h
@@ -16,12 +16,26 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+/// OptionSet which controls when under which conditions request strategies are allowed to make requests.
 typedef NS_OPTIONS(NSUInteger, ZMStrategyConfigurationOption) {
+    /// Strategy is not allowed to make requests.
     ZMStrategyConfigurationOptionDoesNotAllowRequests = 0,
+    /// Strategy is allowed to make requests before the user has authenticated and received a cookie.
     ZMStrategyConfigurationOptionAllowsRequestsWhileUnauthenticated = 1 << 0,
+    /// Strategy is allowed to make requests while the application is operating in the background.
     ZMStrategyConfigurationOptionAllowsRequestsWhileInBackground = 1 << 1,
-    ZMStrategyConfigurationOptionAllowsRequestsWhileOnline = 1 << 4,
-    ZMStrategyConfigurationOptionAllowsRequestsDuringSlowSync = 1 << 2,
-    ZMStrategyConfigurationOptionAllowsRequestsDuringQuickSync = 1 << 3,
-    ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch = 1 << 5
+    /// Strategy is allowed to make requests when the application is online and is receving events via the web socket.
+    ZMStrategyConfigurationOptionAllowsRequestsWhileOnline = 1 << 2,
+    /** Strategy is allowed to make requests during slow sync phase.
+        
+        During the slow sync phase the application is downloading metadata about users, conversations, etc..
+    */
+    ZMStrategyConfigurationOptionAllowsRequestsDuringSlowSync = 1 << 3,
+    /** Strategy is allowed to make requests during quick sync phase.
+     
+        During the quick sync phase the application is catching up on changes since it was last active, during this phase we are downloading and decrypting messages.
+     
+        WARNING: it's important that we don't send any encrypted message during this phase since it can lead to encryption errors.
+     */
+    ZMStrategyConfigurationOptionAllowsRequestsDuringQuickSync = 1 << 4
 };

--- a/Sources/Helpers/ZMStrategyConfigurationOption.h
+++ b/Sources/Helpers/ZMStrategyConfigurationOption.h
@@ -18,24 +18,38 @@
 
 /// OptionSet which controls when under which conditions request strategies are allowed to make requests.
 typedef NS_OPTIONS(NSUInteger, ZMStrategyConfigurationOption) {
-    /// Strategy is not allowed to make requests.
+    
+    /** Strategy is not allowed to make requests.
+     */
     ZMStrategyConfigurationOptionDoesNotAllowRequests = 0,
-    /// Strategy is allowed to make requests before the user has authenticated and received a cookie.
+    
+    /** Strategy is allowed to make requests before the user has authenticated and received a cookie.
+     */
     ZMStrategyConfigurationOptionAllowsRequestsWhileUnauthenticated = 1 << 0,
-    /// Strategy is allowed to make requests while the application is operating in the background.
+    
+    /** Strategy is allowed to make requests while the application is operating in the background.
+     */
     ZMStrategyConfigurationOptionAllowsRequestsWhileInBackground = 1 << 1,
-    /// Strategy is allowed to make requests when the application is online and is receving events via the web socket.
-    ZMStrategyConfigurationOptionAllowsRequestsWhileOnline = 1 << 2,
+    
+    /** Strategy is allowed to make requests while the application is waiting for the websocket to be established.
+     */
+    ZMStrategyConfigurationOptionAllowsRequestsWhileWaitingForWebsocket = 1 << 2,
+    
+    /** Strategy is allowed to make requests when the application is online and is receiving events via the web socket.
+     */
+    ZMStrategyConfigurationOptionAllowsRequestsWhileOnline = 1 << 3,
+    
     /** Strategy is allowed to make requests during slow sync phase.
         
         During the slow sync phase the application is downloading metadata about users, conversations, etc..
     */
-    ZMStrategyConfigurationOptionAllowsRequestsDuringSlowSync = 1 << 3,
+    ZMStrategyConfigurationOptionAllowsRequestsDuringSlowSync = 1 << 4,
+    
     /** Strategy is allowed to make requests during quick sync phase.
      
         During the quick sync phase the application is catching up on changes since it was last active, during this phase we are downloading and decrypting messages.
      
         WARNING: it's important that we don't send any encrypted message during this phase since it can lead to encryption errors.
      */
-    ZMStrategyConfigurationOptionAllowsRequestsDuringQuickSync = 1 << 4
+    ZMStrategyConfigurationOptionAllowsRequestsDuringQuickSync = 1 << 5
 };

--- a/Sources/Protocols/ApplicationStatus.swift
+++ b/Sources/Protocols/ApplicationStatus.swift
@@ -18,19 +18,16 @@
 
 import Foundation
 
-@objc public protocol BackgroundNotificationFetchStatusProvider {
-    var status: BackgroundNotificationFetchStatus { get }
-}
-
-@objc public enum BackgroundNotificationFetchStatus: UInt8 {
+@objc public enum NotificationStreamFetchState: UInt8 {
     case done, inProgress
 }
 
 @objc(ZMSynchronizationState)
 public enum SynchronizationState : UInt {
     case unauthenticated
-    case synchronizing
-    case eventProcessing
+    case slowSyncing
+    case quickSyncing
+    case online
 }
 
 @objc(ZMOperationState)
@@ -43,12 +40,11 @@ public enum OperationState : UInt {
 public protocol ApplicationStatus : class {
     var synchronizationState : SynchronizationState { get }
     var operationState : OperationState { get }
+    var notificationStreamFetchState: NotificationStreamFetchState { get }
     
     var clientRegistrationDelegate : ClientRegistrationDelegate { get }
     var requestCancellation : ZMRequestCancellation { get }
 
-    var notificationFetchStatus: BackgroundNotificationFetchStatus { get }
-    
     func requestSlowSync()
 
 }

--- a/Sources/Protocols/ApplicationStatus.swift
+++ b/Sources/Protocols/ApplicationStatus.swift
@@ -18,14 +18,11 @@
 
 import Foundation
 
-@objc public enum NotificationStreamFetchState: UInt8 {
-    case done, inProgress
-}
-
 @objc(ZMSynchronizationState)
 public enum SynchronizationState : UInt {
     case unauthenticated
     case slowSyncing
+    case establishingWebsocket
     case quickSyncing
     case online
 }
@@ -39,9 +36,7 @@ public enum OperationState : UInt {
 @objc(ZMApplicationStatus)
 public protocol ApplicationStatus : class {
     var synchronizationState : SynchronizationState { get }
-    var operationState : OperationState { get }
-    var notificationStreamFetchState: NotificationStreamFetchState { get }
-    
+    var operationState : OperationState { get }    
     var clientRegistrationDelegate : ClientRegistrationDelegate { get }
     var requestCancellation : ZMRequestCancellation { get }
 

--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -36,7 +36,9 @@ public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, Z
 
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-        configuration = [.allowsRequestsDuringEventProcessing, .allowsRequestsWhileInBackground]
+        
+        configuration = [.allowsRequestsWhileOnline,
+                         .allowsRequestsWhileInBackground]
 
         upstreamSync = ZMUpstreamModifiedObjectSync(
             transcoder: self,

--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -62,7 +62,7 @@ class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         super.setUp()
         
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
         
         self.syncMOC.performGroupedBlockAndWait {
             self.sut = AssetClientMessageRequestStrategy(withManagedObjectContext: self.syncMOC, applicationStatus: self.mockApplicationStatus)

--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategy.swift
@@ -33,7 +33,7 @@ fileprivate let zmLog = ZMSLog(tag: "Asset V3")
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
 
-        configuration = .allowsRequestsDuringEventProcessing
+        configuration = .allowsRequestsWhileOnline
 
         let downloadPredicate = NSPredicate { (object, _) -> Bool in
             guard let message = object as? ZMAssetClientMessage else { return false }

--- a/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
@@ -51,7 +51,7 @@ class AssetV3DownloadRequestStrategyTests: MessagingTestBase {
         super.setUp()
         
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
         sut = AssetV3DownloadRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: mockApplicationStatus)
         
         self.syncMOC.performGroupedBlockAndWait {

--- a/Sources/Request Strategies/Assets/AssetV3PreviewDownloadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetV3PreviewDownloadRequestStrategyTests.swift
@@ -37,7 +37,7 @@ class AssetV3PreviewDownloadRequestStrategyTests: MessagingTestBase {
     override func setUp() {
         super.setUp()
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
         self.syncMOC.performGroupedBlockAndWait {
             self.sut = AssetV3PreviewDownloadRequestStrategy(withManagedObjectContext: self.syncMOC, applicationStatus: self.mockApplicationStatus)
             self.conversation = self.createConversation()

--- a/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
@@ -31,7 +31,7 @@ public final class AssetV3UploadRequestStrategy: AbstractRequestStrategy, ZMCont
         preprocessor = AssetsPreprocessor(managedObjectContext: managedObjectContext)
         
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-        configuration = .allowsRequestsDuringEventProcessing
+        configuration = .allowsRequestsWhileOnline
         
         upstreamSync = ZMUpstreamModifiedObjectSync(
             transcoder: self,

--- a/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategyTests.swift
@@ -28,7 +28,7 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         super.setUp()
         
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
         sut = AssetV3UploadRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: mockApplicationStatus)
     }
 

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategyTests.swift
@@ -35,7 +35,7 @@ class LinkPreviewAssetDownloadRequestStrategyTests: MessagingTestBase {
         super.setUp()
         self.syncMOC.performGroupedAndWait { syncMOC in
             self.mockApplicationStatus = MockApplicationStatus()
-            self.mockApplicationStatus.mockSynchronizationState = .eventProcessing
+            self.mockApplicationStatus.mockSynchronizationState = .online
             self.oneToOneconversationOnSync = syncMOC.object(with: self.oneToOneConversation.objectID) as? ZMConversation
 
             self.sut = LinkPreviewAssetDownloadRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: self.mockApplicationStatus)

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategyTests.swift
@@ -33,7 +33,7 @@ class LinkPreviewAssetUploadRequestStrategyTests: MessagingTestBase {
         super.setUp()
         
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
 
         self.sut = LinkPreviewAssetUploadRequestStrategy(managedObjectContext: self.syncMOC, applicationStatus: mockApplicationStatus, linkPreviewPreprocessor: nil, previewImagePreprocessor: nil)
     }

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategy.swift
@@ -27,7 +27,7 @@ public final class LinkPreviewUploadRequestStrategy: AbstractRequestStrategy, ZM
 
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-        configuration = .allowsRequestsDuringEventProcessing
+        configuration = .allowsRequestsWhileOnline
 
         upstreamSync = ZMUpstreamModifiedObjectSync(
             transcoder: self,

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUploadRequestStrategyTests.swift
@@ -30,7 +30,7 @@ class LinkPreviewUploadRequestStrategyTests: MessagingTestBase {
         super.setUp()
         self.syncMOC.performGroupedAndWait { syncMOC in
             self.applicationStatus = MockApplicationStatus()
-            self.applicationStatus.mockSynchronizationState = .eventProcessing
+            self.applicationStatus.mockSynchronizationState = .online
             self.sut = LinkPreviewUploadRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: self.applicationStatus)
         }
     }

--- a/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
@@ -28,7 +28,7 @@ import WireTransport
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
-        configuration = [.allowsRequestsDuringEventProcessing]
+        configuration = [.allowsRequestsWhileOnline]
         
         let downloadPredicate = NSPredicate { (object, _) -> Bool in
             guard let message = object as? ZMAssetClientMessage else { return false }

--- a/Sources/Request Strategies/Assets/V2/ImageV2DownloadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/V2/ImageV2DownloadRequestStrategyTests.swift
@@ -30,7 +30,7 @@ class ImageV2DownloadRequestStrategyTests: MessagingTestBase {
     override func setUp() {
         super.setUp()
         applicationStatus = MockApplicationStatus()
-        applicationStatus.mockSynchronizationState = .eventProcessing
+        applicationStatus.mockSynchronizationState = .online
         sut = ImageV2DownloadRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: applicationStatus)
     }
     

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
@@ -30,7 +30,7 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
 
         self.syncMOC.performGroupedAndWait { moc in
             self.applicationStatus = MockApplicationStatus()
-            self.applicationStatus.mockSynchronizationState = .eventProcessing
+            self.applicationStatus.mockSynchronizationState = .online
             self.sut = AvailabilityRequestStrategy(withManagedObjectContext: moc, applicationStatus: self.applicationStatus)
         }
     }

--- a/Sources/Request Strategies/Base Strategies/AbstractRequestStrategy.swift
+++ b/Sources/Request Strategies/Base Strategies/AbstractRequestStrategy.swift
@@ -26,8 +26,7 @@ private let zmLog = ZMSLog(tag: "Request Configuration")
     
     public let managedObjectContext : NSManagedObjectContext
     public var configuration : ZMStrategyConfigurationOption = [
-        .allowsRequestsWhileOnline,
-        .allowsRequestsDuringNotificationStreamFetch
+        .allowsRequestsWhileOnline
     ]
     
     public init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
@@ -70,7 +69,8 @@ private let zmLog = ZMSLog(tag: "Request Configuration")
             prerequisites.insert(.allowsRequestsDuringSlowSync)
         }
         
-        if applicationStatus.synchronizationState == .quickSyncing {
+        if applicationStatus.synchronizationState == .quickSyncing ||
+           applicationStatus.notificationStreamFetchState == .inProgress {
             prerequisites.insert(.allowsRequestsDuringQuickSync)
         }
         
@@ -80,13 +80,6 @@ private let zmLog = ZMSLog(tag: "Request Configuration")
         
         if applicationStatus.operationState == .background {
             prerequisites.insert(.allowsRequestsWhileInBackground)
-        }
-
-        if applicationStatus.notificationStreamFetchState == .inProgress {
-            // Don't create requests while we are still fetching the notification stream in the background.
-            // Otherwise we risk already sending out OTR messages when we have to fetch
-            // multiple pages of the stream (in case we have been offline for a while).
-            prerequisites.insert(.allowsRequestsDuringNotificationStreamFetch)
         }
 
         return prerequisites

--- a/Sources/Request Strategies/Base Strategies/AbstractRequestStrategy.swift
+++ b/Sources/Request Strategies/Base Strategies/AbstractRequestStrategy.swift
@@ -25,7 +25,10 @@ private let zmLog = ZMSLog(tag: "Request Configuration")
     weak public var applicationStatus : ApplicationStatus?
     
     public let managedObjectContext : NSManagedObjectContext
-    public var configuration : ZMStrategyConfigurationOption = [.allowsRequestsDuringEventProcessing, .allowsRequestsDuringNotificationStreamFetch]
+    public var configuration : ZMStrategyConfigurationOption = [
+        .allowsRequestsWhileOnline,
+        .allowsRequestsDuringNotificationStreamFetch
+    ]
     
     public init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         self.managedObjectContext = managedObjectContext
@@ -63,19 +66,23 @@ private let zmLog = ZMSLog(tag: "Request Configuration")
             prerequisites.insert(.allowsRequestsWhileUnauthenticated)
         }
         
-        if applicationStatus.synchronizationState == .synchronizing {
-            prerequisites.insert(.allowsRequestsDuringSync)
+        if applicationStatus.synchronizationState == .slowSyncing {
+            prerequisites.insert(.allowsRequestsDuringSlowSync)
         }
         
-        if applicationStatus.synchronizationState == .eventProcessing {
-            prerequisites.insert(.allowsRequestsDuringEventProcessing)
+        if applicationStatus.synchronizationState == .quickSyncing {
+            prerequisites.insert(.allowsRequestsDuringQuickSync)
+        }
+        
+        if applicationStatus.synchronizationState == .online {
+            prerequisites.insert(.allowsRequestsWhileOnline)
         }
         
         if applicationStatus.operationState == .background {
             prerequisites.insert(.allowsRequestsWhileInBackground)
         }
 
-        if applicationStatus.notificationFetchStatus == .inProgress {
+        if applicationStatus.notificationStreamFetchState == .inProgress {
             // Don't create requests while we are still fetching the notification stream in the background.
             // Otherwise we risk already sending out OTR messages when we have to fetch
             // multiple pages of the stream (in case we have been offline for a while).

--- a/Sources/Request Strategies/Base Strategies/AbstractRequestStrategy.swift
+++ b/Sources/Request Strategies/Base Strategies/AbstractRequestStrategy.swift
@@ -68,9 +68,12 @@ private let zmLog = ZMSLog(tag: "Request Configuration")
         if applicationStatus.synchronizationState == .slowSyncing {
             prerequisites.insert(.allowsRequestsDuringSlowSync)
         }
+                
+        if applicationStatus.synchronizationState == .establishingWebsocket {
+            prerequisites.insert(.allowsRequestsWhileWaitingForWebsocket)
+        }
         
-        if applicationStatus.synchronizationState == .quickSyncing ||
-           applicationStatus.notificationStreamFetchState == .inProgress {
+        if applicationStatus.synchronizationState == .quickSyncing {
             prerequisites.insert(.allowsRequestsDuringQuickSync)
         }
         

--- a/Sources/Request Strategies/Base Strategies/AbstractRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Base Strategies/AbstractRequestStrategyTests.swift
@@ -67,29 +67,147 @@ class AbstractRequestStrategyTests : MessagingTestBase {
     let mockApplicationStatus = MockApplicationStatus()
     
     func checkAllPermutations(on sut : RequestStrategy & TestableAbstractRequestStrategy) {
-        
-        assertPass(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .online, sut: sut)
-        assertPass(withConfiguration: [.allowsRequestsDuringSlowSync], operationState: .foreground, synchronizationState: .slowSyncing, sut: sut)
-        assertPass(withConfiguration: [.allowsRequestsDuringQuickSync], operationState: .foreground, synchronizationState: .quickSyncing, sut: sut)
-        assertPass(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
-        
-        assertFail(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .slowSyncing, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .quickSyncing, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
-        
-        assertFail(withConfiguration: [.allowsRequestsDuringSlowSync], operationState: .foreground, synchronizationState: .online, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsDuringSlowSync], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
-        
-        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .online, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .slowSyncing, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .quickSyncing, sut: sut)
-        
-        assertPass(withConfiguration: [.allowsRequestsWhileOnline, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .online, sut: sut)
-        assertPass(withConfiguration: [.allowsRequestsDuringQuickSync, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .quickSyncing, sut: sut)
-        assertPass(withConfiguration: [.allowsRequestsWhileUnauthenticated, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .unauthenticated, sut: sut)
+        checkRequirementsDependingOn_SynchronizationState(on: sut)
+        checkRequirementsDependingOn_OperationState(on: sut)
     }
     
-    func assertPass(withConfiguration configuration: ZMStrategyConfigurationOption, operationState: OperationState, synchronizationState: SynchronizationState, sut: RequestStrategy & TestableAbstractRequestStrategy) {
+    func checkRequirementsDependingOn_SynchronizationState(on sut : RequestStrategy & TestableAbstractRequestStrategy) {
+        
+        // online
+        
+        assertPass(withConfiguration: [.allowsRequestsWhileOnline],
+                   operationState: .foreground,
+                   synchronizationState: .online,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsWhileOnline],
+                   operationState: .foreground,
+                   synchronizationState: .slowSyncing,
+                   sut: sut)
+
+        assertFail(withConfiguration: [.allowsRequestsWhileOnline],
+                   operationState: .foreground,
+                   synchronizationState: .quickSyncing,
+                   sut: sut)
+
+        assertFail(withConfiguration: [.allowsRequestsWhileOnline],
+                   operationState: .foreground,
+                   synchronizationState: .unauthenticated,
+                   sut: sut)
+        
+        // slow sync
+        
+        assertPass(withConfiguration: [.allowsRequestsDuringSlowSync],
+                   operationState: .foreground,
+                   synchronizationState: .slowSyncing,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsDuringSlowSync],
+                   operationState: .foreground,
+                   synchronizationState: .online,
+                   sut: sut)
+
+        assertFail(withConfiguration: [.allowsRequestsDuringSlowSync],
+                   operationState: .foreground,
+                   synchronizationState: .unauthenticated,
+                   sut: sut)
+        
+        
+        // waiting for websocket
+        
+        assertPass(withConfiguration: [.allowsRequestsWhileWaitingForWebsocket],
+                   operationState: .foreground,
+                   synchronizationState: .establishingWebsocket,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsWhileWaitingForWebsocket],
+                   operationState: .foreground,
+                   synchronizationState: .quickSyncing,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsWhileWaitingForWebsocket],
+                   operationState: .foreground,
+                   synchronizationState: .online,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsWhileWaitingForWebsocket],
+                   operationState: .foreground,
+                   synchronizationState: .unauthenticated,
+                   sut: sut)
+        
+        // quick sync
+        
+        assertPass(withConfiguration: [.allowsRequestsDuringQuickSync],
+                   operationState: .foreground,
+                   synchronizationState: .quickSyncing,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsDuringQuickSync],
+                   operationState: .foreground,
+                   synchronizationState: .establishingWebsocket,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsDuringQuickSync],
+                   operationState: .foreground,
+                   synchronizationState: .slowSyncing,
+                   sut: sut)
+
+        assertFail(withConfiguration: [.allowsRequestsDuringQuickSync],
+                   operationState: .foreground,
+                   synchronizationState: .online,
+                   sut: sut)
+
+        assertFail(withConfiguration: [.allowsRequestsDuringQuickSync],
+                   operationState: .foreground,
+                   synchronizationState: .unauthenticated,
+                   sut: sut)
+        
+        // unauthenticated
+        
+        assertPass(withConfiguration: [.allowsRequestsWhileUnauthenticated],
+                   operationState: .foreground,
+                   synchronizationState: .unauthenticated,
+                   sut: sut)
+        
+        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated],
+                   operationState: .foreground,
+                   synchronizationState: .online,
+                   sut: sut)
+
+        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated],
+                   operationState: .foreground,
+                   synchronizationState: .slowSyncing,
+                   sut: sut)
+
+        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated],
+                   operationState: .foreground,
+                   synchronizationState: .quickSyncing,
+                   sut: sut)
+    }
+    
+    func checkRequirementsDependingOn_OperationState(on sut : RequestStrategy & TestableAbstractRequestStrategy) {
+        assertPass(withConfiguration: [.allowsRequestsWhileOnline, .allowsRequestsWhileInBackground],
+                   operationState: .background,
+                   synchronizationState: .online,
+                   sut: sut)
+        
+        assertPass(withConfiguration: [.allowsRequestsDuringQuickSync, .allowsRequestsWhileInBackground],
+                   operationState: .background,
+                   synchronizationState: .quickSyncing,
+                   sut: sut)
+        
+        assertPass(withConfiguration: [.allowsRequestsWhileUnauthenticated, .allowsRequestsWhileInBackground],
+                   operationState: .background,
+                   synchronizationState: .unauthenticated,
+                   sut: sut)
+    }
+        
+    func assertPass(withConfiguration configuration: ZMStrategyConfigurationOption,
+                    operationState: OperationState,
+                    synchronizationState: SynchronizationState,
+                    sut: RequestStrategy & TestableAbstractRequestStrategy,
+                    file: StaticString = #file,
+                    line: UInt = #line) {
         
         // given
         sut.mutableConfiguration = configuration
@@ -97,10 +215,15 @@ class AbstractRequestStrategyTests : MessagingTestBase {
         mockApplicationStatus.mockSynchronizationState = synchronizationState
         
         // then
-        XCTAssertNotNil(sut.nextRequest(), "expected \(configuration) to pass")
+        XCTAssertNotNil(sut.nextRequest(), "expected \(configuration) to pass", file: file, line: line)
     }
     
-    func assertFail(withConfiguration configuration: ZMStrategyConfigurationOption, operationState: OperationState, synchronizationState: SynchronizationState, sut: RequestStrategy & TestableAbstractRequestStrategy) {
+    func assertFail(withConfiguration configuration: ZMStrategyConfigurationOption,
+                    operationState: OperationState,
+                    synchronizationState: SynchronizationState,
+                    sut: RequestStrategy & TestableAbstractRequestStrategy,
+                    file: StaticString = #file,
+                    line: UInt = #line) {
         
         // given
         sut.mutableConfiguration = configuration
@@ -108,7 +231,7 @@ class AbstractRequestStrategyTests : MessagingTestBase {
         mockApplicationStatus.mockSynchronizationState = synchronizationState
         
         // then
-        XCTAssertNil(sut.nextRequest(), "expected \(configuration) to fail")
+        XCTAssertNil(sut.nextRequest(), "expected \(configuration) to fail", file: file, line: line)
     }
     
     func testAbstractRequestStrategy() {

--- a/Sources/Request Strategies/Base Strategies/AbstractRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Base Strategies/AbstractRequestStrategyTests.swift
@@ -68,21 +68,24 @@ class AbstractRequestStrategyTests : MessagingTestBase {
     
     func checkAllPermutations(on sut : RequestStrategy & TestableAbstractRequestStrategy) {
         
-        assertPass(withConfiguration: [.allowsRequestsDuringEventProcessing], operationState: .foreground, synchronizationState: .eventProcessing, sut: sut)
-        assertPass(withConfiguration: [.allowsRequestsDuringSync], operationState: .foreground, synchronizationState: .synchronizing, sut: sut)
+        assertPass(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .online, sut: sut)
+        assertPass(withConfiguration: [.allowsRequestsDuringSlowSync], operationState: .foreground, synchronizationState: .slowSyncing, sut: sut)
+        assertPass(withConfiguration: [.allowsRequestsDuringQuickSync], operationState: .foreground, synchronizationState: .quickSyncing, sut: sut)
         assertPass(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
         
-        assertFail(withConfiguration: [.allowsRequestsDuringEventProcessing], operationState: .foreground, synchronizationState: .synchronizing, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsDuringEventProcessing], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .slowSyncing, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .quickSyncing, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsWhileOnline], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
         
-        assertFail(withConfiguration: [.allowsRequestsDuringSync], operationState: .foreground, synchronizationState: .eventProcessing, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsDuringSync], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsDuringSlowSync], operationState: .foreground, synchronizationState: .online, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsDuringSlowSync], operationState: .foreground, synchronizationState: .unauthenticated, sut: sut)
         
-        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .eventProcessing, sut: sut)
-        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .synchronizing, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .online, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .slowSyncing, sut: sut)
+        assertFail(withConfiguration: [.allowsRequestsWhileUnauthenticated], operationState: .foreground, synchronizationState: .quickSyncing, sut: sut)
         
-        assertPass(withConfiguration: [.allowsRequestsDuringEventProcessing, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .eventProcessing, sut: sut)
-        assertPass(withConfiguration: [.allowsRequestsDuringSync, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .synchronizing, sut: sut)
+        assertPass(withConfiguration: [.allowsRequestsWhileOnline, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .online, sut: sut)
+        assertPass(withConfiguration: [.allowsRequestsDuringQuickSync, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .quickSyncing, sut: sut)
         assertPass(withConfiguration: [.allowsRequestsWhileUnauthenticated, .allowsRequestsWhileInBackground], operationState: .background, synchronizationState: .unauthenticated, sut: sut)
     }
     

--- a/Sources/Request Strategies/Base Strategies/ZMAbstractRequestStrategy.m
+++ b/Sources/Request Strategies/Base Strategies/ZMAbstractRequestStrategy.m
@@ -56,7 +56,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"Request Configuration";
 {
     ZMStrategyConfigurationOption option = 0;
     
-    for (NSUInteger index = 0; option <= ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing; index++) {
+    for (NSUInteger index = 0; option <= ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch; index++) {
         option = 1 << index;
         
         if ((prerequisites & option) == option && (configuration & option) != option) {

--- a/Sources/Request Strategies/Base Strategies/ZMAbstractRequestStrategy.m
+++ b/Sources/Request Strategies/Base Strategies/ZMAbstractRequestStrategy.m
@@ -56,7 +56,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"Request Configuration";
 {
     ZMStrategyConfigurationOption option = 0;
     
-    for (NSUInteger index = 0; option <= ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch; index++) {
+    for (NSUInteger index = 0; option <= ZMStrategyConfigurationOptionAllowsRequestsDuringQuickSync; index++) {
         option = 1 << index;
         
         if ((prerequisites & option) == option && (configuration & option) != option) {

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoder.swift
@@ -43,7 +43,8 @@ public class ClientMessageTranscoder: AbstractRequestStrategy {
         
         super.init(withManagedObjectContext: moc, applicationStatus: applicationStatus)
         
-        self.configuration = [.allowsRequestsDuringEventProcessing, .allowsRequestsWhileInBackground]
+        self.configuration = [.allowsRequestsWhileOnline,
+                              .allowsRequestsWhileInBackground]
         self.upstreamObjectSync = ZMUpstreamInsertedObjectSync(transcoder: self, entityName: ZMClientMessage.entityName(), filter: ClientMessageTranscoder.insertFilter, managedObjectContext: moc)
         self.deleteOldEphemeralMessages()
     }

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests+MessageConfirmation.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests+MessageConfirmation.swift
@@ -51,13 +51,13 @@ extension ClientMessageTranscoderTests {
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
 
             // When
-            self.mockApplicationStatus.notificationStreamFetchState = .inProgress
+            self.mockApplicationStatus.mockSynchronizationState = .quickSyncing
 
             // Then
             XCTAssertNil(self.sut.nextRequest())
 
             // When
-            self.mockApplicationStatus.notificationStreamFetchState = .done
+            self.mockApplicationStatus.mockSynchronizationState = .online
             // Then
             guard let request = self.sut.nextRequest() else { return XCTFail() }
 

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests+MessageConfirmation.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests+MessageConfirmation.swift
@@ -51,13 +51,13 @@ extension ClientMessageTranscoderTests {
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
 
             // When
-            self.mockApplicationStatus.notificationFetchStatus = .inProgress
+            self.mockApplicationStatus.notificationStreamFetchState = .inProgress
 
             // Then
             XCTAssertNil(self.sut.nextRequest())
 
             // When
-            self.mockApplicationStatus.notificationFetchStatus = .done
+            self.mockApplicationStatus.notificationStreamFetchState = .done
             // Then
             guard let request = self.sut.nextRequest() else { return XCTFail() }
 

--- a/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageTranscoderTests.swift
@@ -30,7 +30,7 @@ class ClientMessageTranscoderTests: MessagingTestBase {
         super.setUp()
         self.localNotificationDispatcher = MockPushMessageHandler()
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
         mockAttachmentsDetector = MockAttachmentDetector()
         LinkAttachmentDetectorHelper.setTest_debug_linkAttachmentDetector(mockAttachmentsDetector)
         sut = ClientMessageTranscoder(in: syncMOC, localNotificationDispatcher: localNotificationDispatcher, applicationStatus: mockApplicationStatus)

--- a/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
+++ b/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
@@ -44,23 +44,28 @@ extension ZMUpdateEvent {
 }
 
 @objcMembers
-public final class DeliveryReceiptRequestStrategy: NSObject, RequestStrategy {
+public final class DeliveryReceiptRequestStrategy: AbstractRequestStrategy {
     
-    private let managedObjectContext: NSManagedObjectContext
     private let genericMessageStrategy: GenericMessageRequestStrategy
     
     // MARK: - Init
     
     public init(managedObjectContext: NSManagedObjectContext,
+                applicationStatus: ApplicationStatus,
                 clientRegistrationDelegate: ClientRegistrationDelegate) {
         
-        self.managedObjectContext = managedObjectContext
         self.genericMessageStrategy = GenericMessageRequestStrategy(context: managedObjectContext, clientRegistrationDelegate: clientRegistrationDelegate)
+        
+        super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
+        
+        self.configuration = [.allowsRequestsWhileInBackground,
+                              .allowsRequestsWhileOnline,
+                              .allowsRequestsDuringQuickSync]
     }
     
     // MARK: - Methods
     
-    public func nextRequest() -> ZMTransportRequest? {
+    public override func nextRequestIfAllowed() -> ZMTransportRequest? {
         return genericMessageStrategy.nextRequest()
     }
 }

--- a/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
+++ b/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
@@ -60,7 +60,7 @@ public final class DeliveryReceiptRequestStrategy: AbstractRequestStrategy {
         
         self.configuration = [.allowsRequestsWhileInBackground,
                               .allowsRequestsWhileOnline,
-                              .allowsRequestsDuringQuickSync]
+                              .allowsRequestsWhileWaitingForWebsocket]
     }
     
     // MARK: - Methods

--- a/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
@@ -21,6 +21,7 @@ import XCTest
 
 class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
     
+    var mockApplicationStatus: MockApplicationStatus!
     var mockClientRegistrationStatus: MockClientRegistrationStatus!
     var secondOneToOneConveration: ZMConversation!
     var secondUser: ZMUser!
@@ -28,9 +29,13 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
     
     override func setUp() {
         super.setUp()
+        mockApplicationStatus = MockApplicationStatus()
+        mockApplicationStatus.mockSynchronizationState = .online
         mockClientRegistrationStatus = MockClientRegistrationStatus()
         
-        sut = DeliveryReceiptRequestStrategy(managedObjectContext: syncMOC, clientRegistrationDelegate: mockClientRegistrationStatus)
+        sut = DeliveryReceiptRequestStrategy(managedObjectContext: syncMOC,
+                                             applicationStatus: mockApplicationStatus,
+                                             clientRegistrationDelegate: mockClientRegistrationStatus)
         
         syncMOC.performGroupedBlockAndWait {
             let user = ZMUser.insertNewObject(in: self.syncMOC)
@@ -46,6 +51,7 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
         secondUser = nil
         secondOneToOneConveration = nil
         mockClientRegistrationStatus = nil
+        mockApplicationStatus = nil
         super.tearDown()
     }
     

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -59,7 +59,7 @@ public final class FetchingClientRequestStrategy : AbstractRequestStrategy {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
         self.configuration = [.allowsRequestsWhileOnline,
-                              .allowsRequestsDuringNotificationStreamFetch,
+                              .allowsRequestsDuringQuickSync,
                               .allowsRequestsWhileInBackground]
         self.userClientsObserverToken = NotificationInContext.addObserver(name: FetchingClientRequestStrategy.needsToUpdateUserClientsNotificationName,
                                                                           context: self.managedObjectContext.notificationContext,

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -58,7 +58,9 @@ public final class FetchingClientRequestStrategy : AbstractRequestStrategy {
         
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
-        self.configuration = [.allowsRequestsDuringEventProcessing, .allowsRequestsDuringNotificationStreamFetch, .allowsRequestsWhileInBackground]
+        self.configuration = [.allowsRequestsWhileOnline,
+                              .allowsRequestsDuringNotificationStreamFetch,
+                              .allowsRequestsWhileInBackground]
         self.userClientsObserverToken = NotificationInContext.addObserver(name: FetchingClientRequestStrategy.needsToUpdateUserClientsNotificationName,
                                                                           context: self.managedObjectContext.notificationContext,
                                                                           object: nil)

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
@@ -30,7 +30,7 @@ class FetchClientRequestStrategyTests : MessagingTestBase {
     override func setUp() {
         super.setUp()
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
         sut = FetchingClientRequestStrategy(withManagedObjectContext: self.syncMOC, applicationStatus: mockApplicationStatus)
         NotificationCenter.default.addObserver(self, selector: #selector(FetchClientRequestStrategyTests.didReceiveAuthenticationNotification(_:)), name: NSNotification.Name(rawValue: "ZMUserSessionAuthenticationNotificationName"), object: nil)
         

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -36,7 +36,7 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
         self.configuration =  [
-            .allowsRequestsDuringEventProcessing,
+            .allowsRequestsWhileOnline,
             .allowsRequestsWhileInBackground,
             .allowsRequestsDuringNotificationStreamFetch
         ]

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -38,7 +38,7 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
         self.configuration =  [
             .allowsRequestsWhileOnline,
             .allowsRequestsWhileInBackground,
-            .allowsRequestsDuringNotificationStreamFetch
+            .allowsRequestsDuringQuickSync
         ]
         self.modifiedSync = ZMUpstreamModifiedObjectSync(transcoder: self, entityName: UserClient.entityName(), update: modifiedPredicate(), filter: nil, keysToSync: [ZMUserClientMissingKey], managedObjectContext: managedObjectContext)
     }

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
@@ -37,7 +37,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
 
         self.syncMOC.performGroupedAndWait { syncMOC in
             self.mockApplicationStatus = MockApplicationStatus()
-            self.mockApplicationStatus.mockSynchronizationState = .eventProcessing
+            self.mockApplicationStatus.mockSynchronizationState = .online
             self.sut = MissingClientsRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: self.mockApplicationStatus)
         }
     }

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -33,7 +33,9 @@ public final class VerifyLegalHoldRequestStrategy: AbstractRequestStrategy {
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
-        configuration = [.allowsRequestsDuringEventProcessing, .allowsRequestsDuringNotificationStreamFetch, .allowsRequestsWhileInBackground]
+        configuration = [.allowsRequestsWhileOnline,
+                         .allowsRequestsDuringNotificationStreamFetch,
+                         .allowsRequestsWhileInBackground]
         conversationSync = IdentifierObjectSync(managedObjectContext: managedObjectContext, transcoder: self)
     }
     

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -34,7 +34,7 @@ public final class VerifyLegalHoldRequestStrategy: AbstractRequestStrategy {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
         configuration = [.allowsRequestsWhileOnline,
-                         .allowsRequestsDuringNotificationStreamFetch,
+                         .allowsRequestsDuringQuickSync,
                          .allowsRequestsWhileInBackground]
         conversationSync = IdentifierObjectSync(managedObjectContext: managedObjectContext, transcoder: self)
     }

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
@@ -41,7 +41,7 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
     override func setUp() {
         super.setUp()
         mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .eventProcessing
+        mockApplicationStatus.mockSynchronizationState = .online
         sut = VerifyLegalHoldRequestStrategy(withManagedObjectContext: self.syncMOC, applicationStatus: mockApplicationStatus)
     }
     

--- a/Sources/Request Strategies/User/UserPropertyRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User/UserPropertyRequestStrategyTests.swift
@@ -30,7 +30,7 @@ class UserPropertyRequestStrategyTests: MessagingTestBase {
         
         self.syncMOC.performGroupedAndWait { moc in
             self.applicationStatus = MockApplicationStatus()
-            self.applicationStatus.mockSynchronizationState = .eventProcessing
+            self.applicationStatus.mockSynchronizationState = .online
             self.sut = UserPropertyRequestStrategy(withManagedObjectContext: moc, applicationStatus: self.applicationStatus)
         }
     }

--- a/Sources/Request Strategies/User/UserRichProfileRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User/UserRichProfileRequestStrategyTests.swift
@@ -29,7 +29,7 @@ class UserRichProfileRequestStrategyTests: MessagingTestBase {
         
         self.syncMOC.performGroupedAndWait { moc in
             self.applicationStatus = MockApplicationStatus()
-            self.applicationStatus.mockSynchronizationState = .eventProcessing
+            self.applicationStatus.mockSynchronizationState = .online
             self.sut = UserRichProfileRequestStrategy(withManagedObjectContext: moc, applicationStatus: self.applicationStatus)
         }
     }

--- a/Tests/Helpers/MockObjects.swift
+++ b/Tests/Helpers/MockObjects.swift
@@ -31,17 +31,14 @@ public class MockApplicationStatus : NSObject, ApplicationStatus {
         return self.mockClientRegistrationStatus
     }
 
-    public var notificationStreamFetchState: NotificationStreamFetchState = .done
-
+    public var mockSynchronizationState : SynchronizationState = .unauthenticated
     public let mockTaskCancellationDelegate = MockTaskCancellationDelegate()
     public var mockClientRegistrationStatus = MockClientRegistrationStatus()
-    
-    public var mockSynchronizationState : SynchronizationState = .unauthenticated
     
     public var synchronizationState: SynchronizationState {
         return mockSynchronizationState
     }
-
+    
     public var mockOperationState : OperationState = .foreground
     
     public var operationState: OperationState {

--- a/Tests/Helpers/MockObjects.swift
+++ b/Tests/Helpers/MockObjects.swift
@@ -31,7 +31,7 @@ public class MockApplicationStatus : NSObject, ApplicationStatus {
         return self.mockClientRegistrationStatus
     }
 
-    public var notificationFetchStatus = BackgroundNotificationFetchStatus.done
+    public var notificationStreamFetchState: NotificationStreamFetchState = .done
 
     public let mockTaskCancellationDelegate = MockTaskCancellationDelegate()
     public var mockClientRegistrationStatus = MockClientRegistrationStatus()


### PR DESCRIPTION
## What's new in this PR?

### Issues

It was possible that the `DeliveryReceiptRequestStrategy` could start sending encrypted messages before we've finished fetching and decrypting all encrypted events in the notification stream.

### Causes

The `DeliveryReceiptRequestStrategy` was not a subclass of `AbstractRequestStrategy` and therefore weren't following any rules about when it's allowed to make requests.

### Solutions

Make `DeliveryReceiptRequestStrategy` an `AbstractRequestStrategy` and configure it not run during quickSync phase, which is the phase where we download and decrypt events.

In order to express this the `ZMStrategyConfigurationOption` was expanded to differentiate between: 
- slow syncing
- quick syncing 
- waiting for the web socket  connection.