### PR TITLE
[Performance] Use more efficient method to check existence of data in cache

### DIFF
--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
@@ -44,15 +44,15 @@ extension ZMImagePreprocessingTracker {
         let imageFetchPredicate = NSPredicate(format: "%K == %d",ZMClientMessage.linkPreviewStateKey, ZMLinkPreviewState.downloaded.rawValue)
         let needsProccessing = NSPredicate { object, _ in
             guard let message = object as? ZMClientMessage else { return false }
-            return nil != managedObjectContext.zm_fileAssetCache.assetData(message, format: .original, encrypted: false)
+            return managedObjectContext.zm_fileAssetCache.hasDataOnDisk(message, format: .original, encrypted: false)
         }
         
         let previewImagePreprocessor = ZMImagePreprocessingTracker(
-            managedObjectContext:       managedObjectContext,
-            imageProcessingQueue:       OperationQueue(),
-            fetch:             imageFetchPredicate,
-            needsProcessingPredicate:   needsProccessing,
-            entityClass:                ZMClientMessage.self
+            managedObjectContext: managedObjectContext,
+            imageProcessingQueue: OperationQueue(),
+            fetch: imageFetchPredicate,
+            needsProcessingPredicate: needsProccessing,
+            entityClass: ZMClientMessage.self
         )
         return previewImagePreprocessor
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The predicate used to determine which `ZMClientMessage` instances require image processing is inefficient.

### Causes

The predicate checks there exists any data in the asset cache for the given message. It does this by trying to read the data (in its entirety) and checking if it exists. This relatively slow because it has to read data from disk.

### Solutions

Use a more appropriate method that checks for the existence of data without actually reading it all.

