### PR TITLE
[Feature] Changed the notification object

### DIFF
--- a/Sources/Helpers/FeatureConfiguration/Configurations.swift
+++ b/Sources/Helpers/FeatureConfiguration/Configurations.swift
@@ -30,19 +30,24 @@ extension Feature {
     public enum AppLock: Configurable, Named {
         public static var name: String = "applock"
         public struct Config: Codable {
-            let enforceAppLock: Bool
-            let inactivityTimeoutSecs: UInt
+            public let enforceAppLock: Bool
+            public let inactivityTimeoutSecs: UInt
         }
     }
 }
 
 // MARK: - Feature Responses
-struct FeatureConfigResponse<T: Configurable>: Decodable {
-    var status: Feature.Status
-    var config: T.Config?
+public struct FeatureConfigResponse<T: Configurable>: Decodable {
+    public var status: Feature.Status
+    public var config: T.Config?
     
     var configData: Data? {
         return try? JSONEncoder().encode(config)
+    }
+    
+    init(status: Feature.Status, config: T.Config?) {
+        self.status = status
+        self.config = config
     }
 }
 

--- a/Sources/Helpers/FeatureConfiguration/FeatureController.swift
+++ b/Sources/Helpers/FeatureConfiguration/FeatureController.swift
@@ -66,7 +66,7 @@ extension FeatureController {
             userInfo["configKey"] = config
         }
         
-        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [Feature.AppLock.name : userInfo])
+        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: userInfo)
     }
     
     internal func saveAllFeatures(_ configurations: AllFeatureConfigsResponse) {
@@ -85,6 +85,6 @@ extension FeatureController {
             let config = try? JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig) {
             userInfo["configKey"] = config
         }
-        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [appLockFeature.name : userInfo])
+        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: userInfo)
     }
 }

--- a/Sources/Helpers/FeatureConfiguration/FeatureController.swift
+++ b/Sources/Helpers/FeatureConfiguration/FeatureController.swift
@@ -56,7 +56,12 @@ extension FeatureController {
                                              context: moc)
         
         // TODO: Katerina make it more general for all features
-        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [Feature.AppLock.name : feature])
+        var config: Feature.AppLock.Config?
+        if let featureConfig = feature.config {
+            config = try? JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig)
+        }
+        let featureInfo = FeatureConfigResponse<Feature.AppLock>(status: feature.status, config: config)
+        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [Feature.AppLock.name : featureInfo])
     }
     
     internal func saveAllFeatures(_ configurations: AllFeatureConfigsResponse) {
@@ -66,6 +71,11 @@ extension FeatureController {
                                                     config: appLock.schema.configData,
                                                     context: moc)
         
-        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [appLock.name : appLockFeature])
+        var config: Feature.AppLock.Config?
+        if let featureConfig = appLockFeature.config {
+            config = try? JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig)
+        }
+        let featureInfo = FeatureConfigResponse<Feature.AppLock>(status: appLockFeature.status, config: config)
+        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [appLock.name : featureInfo])
     }
 }

--- a/Sources/Helpers/FeatureConfiguration/FeatureController.swift
+++ b/Sources/Helpers/FeatureConfiguration/FeatureController.swift
@@ -55,13 +55,18 @@ extension FeatureController {
                                              config: configuration.configData,
                                              context: moc)
         
+        var userInfo = [
+            "nameKey": feature.name,
+            "statusKey": feature.status
+            ] as [String : Any]
+        
         // TODO: Katerina make it more general for all features
-        var config: Feature.AppLock.Config?
-        if let featureConfig = feature.config {
-            config = try? JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig)
+        if let featureConfig = feature.config,
+            let config = try? JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig) {
+            userInfo["configKey"] = config
         }
-        let featureInfo = FeatureConfigResponse<Feature.AppLock>(status: feature.status, config: config)
-        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [Feature.AppLock.name : featureInfo])
+        
+        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [Feature.AppLock.name : userInfo])
     }
     
     internal func saveAllFeatures(_ configurations: AllFeatureConfigsResponse) {
@@ -71,11 +76,15 @@ extension FeatureController {
                                                     config: appLock.schema.configData,
                                                     context: moc)
         
-        var config: Feature.AppLock.Config?
-        if let featureConfig = appLockFeature.config {
-            config = try? JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig)
+        var userInfo = [
+            "nameKey": appLockFeature.name,
+            "statusKey": appLockFeature.status
+            ] as [String : Any]
+        
+        if let featureConfig = appLockFeature.config,
+            let config = try? JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig) {
+            userInfo["configKey"] = config
         }
-        let featureInfo = FeatureConfigResponse<Feature.AppLock>(status: appLockFeature.status, config: config)
-        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [appLock.name : featureInfo])
+        NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: [appLockFeature.name : userInfo])
     }
 }

--- a/Sources/Helpers/FeatureConfiguration/FeatureController.swift
+++ b/Sources/Helpers/FeatureConfiguration/FeatureController.swift
@@ -49,7 +49,7 @@ public class FeatureController {
 
 // MARK: - Save to Core Data
 extension FeatureController {
-    internal func save<T: Configurable & Named>(_ feature: T.Type, configuration: FeatureConfigResponse<T>) {
+    func save<T: Configurable & Named>(_ feature: T.Type, configuration: FeatureConfigResponse<T>) {
         let feature = Feature.createOrUpdate(feature.name,
                                              status: configuration.status,
                                              config: configuration.configData,
@@ -69,7 +69,7 @@ extension FeatureController {
         NotificationCenter.default.post(name: FeatureController.featureConfigDidChange, object: nil, userInfo: userInfo)
     }
     
-    internal func saveAllFeatures(_ configurations: AllFeatureConfigsResponse) {
+    func saveAllFeatures(_ configurations: AllFeatureConfigsResponse) {
         let appLock = (name: Feature.AppLock.name, schema: configurations.applock)
         let appLockFeature = Feature.createOrUpdate(appLock.name,
                                                     status: appLock.schema.status,


### PR DESCRIPTION
## What's new in this PR?

- Made `FeatureConfigResponse` public because we can reuse this struct as userInfo in `FeatureController.featureConfigDidChange` notification. 
- Changed type of the `userInfo` in `FeatureController.featureConfigDidChange` notification. 


