### PR TITLE
[Fix] FeatureConfigRequestStrategy: rename property

### DIFF
--- a/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
+++ b/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
@@ -121,7 +121,7 @@ extension FeatureConfigRequestStrategy: ZMDownstreamTranscoder {
             case .appLock:
                 let config = try decoder.decode(ConfigResponse<Feature.AppLock>.self, from: responseData)
                 feature.status = config.status
-                feature.configData = try encoder.encode(config.config)
+                feature.config = try encoder.encode(config.config)
             }
 
             feature.needsToBeUpdatedFromBackend = false


### PR DESCRIPTION
## What's new in this PR?
There have been changes in the DM with the name of the public property. This PR alines the name of the property.

Needs releases with:

- [ feature/feature-configuration-main ] 

