### PR TITLE
[Fix] Don't force unwrap optional timestamp

### DIFF
--- a/Sources/Helpers/EncryptionSessionDirectory+UpdateEvents.swift
+++ b/Sources/Helpers/EncryptionSessionDirectory+UpdateEvents.swift
@@ -90,7 +90,7 @@ extension EncryptionSessionsDirectory {
         var conversation : ZMConversation?
         if let conversationUUID = event.conversationUUID {
             conversation = ZMConversation(remoteID: conversationUUID, createIfNeeded: false, in: moc)
-            conversation?.appendDecryptionFailedSystemMessage(at: event.timestamp!, sender: sender.user!, client: sender, errorCode: Int(error?.rawValue ?? 0))
+            conversation?.appendDecryptionFailedSystemMessage(at: event.timestamp, sender: sender.user!, client: sender, errorCode: Int(error?.rawValue ?? 0))
         }
         
         let userInfo: [String: Any] = [


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would crash upon receiving a message which is marked as transient and can't be decrypted.

### Causes

We ignore the timestamp for transient update events so that property will return `nil`. When we try to add the "Decryption Failed" system message we force unwrap the timestamp and crash.

### Solutions

Don't force unwrap the timestamp since `appendDecryptionFailedSystemMessage()` accepts an optional timestamp.