### PR TITLE
[Fix] Some strategies not running while waiting for the web socket

### DIFF
--- a/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
+++ b/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
@@ -59,6 +59,7 @@ public final class FeatureConfigRequestStrategy: AbstractRequestStrategy, ZMCont
         configuration = [
             .allowsRequestsWhileOnline,
             .allowsRequestsDuringQuickSync,
+            .allowsRequestsWhileWaitingForWebsocket,
             .allowsRequestsWhileInBackground
         ]
         

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -60,6 +60,7 @@ public final class FetchingClientRequestStrategy : AbstractRequestStrategy {
         
         self.configuration = [.allowsRequestsWhileOnline,
                               .allowsRequestsDuringQuickSync,
+                              .allowsRequestsWhileWaitingForWebsocket,
                               .allowsRequestsWhileInBackground]
         self.userClientsObserverToken = NotificationInContext.addObserver(name: FetchingClientRequestStrategy.needsToUpdateUserClientsNotificationName,
                                                                           context: self.managedObjectContext.notificationContext,

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -38,7 +38,8 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
         self.configuration =  [
             .allowsRequestsWhileOnline,
             .allowsRequestsWhileInBackground,
-            .allowsRequestsDuringQuickSync
+            .allowsRequestsDuringQuickSync,
+            .allowsRequestsWhileWaitingForWebsocket,
         ]
         self.modifiedSync = ZMUpstreamModifiedObjectSync(transcoder: self, entityName: UserClient.entityName(), update: modifiedPredicate(), filter: nil, keysToSync: [ZMUserClientMissingKey], managedObjectContext: managedObjectContext)
     }

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -35,6 +35,7 @@ public final class VerifyLegalHoldRequestStrategy: AbstractRequestStrategy {
         
         configuration = [.allowsRequestsWhileOnline,
                          .allowsRequestsDuringQuickSync,
+                         .allowsRequestsWhileWaitingForWebsocket,
                          .allowsRequestsWhileInBackground]
         conversationSync = IdentifierObjectSync(managedObjectContext: managedObjectContext, transcoder: self)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The client fetching strategy wouldn't run after the changes made in https://github.com/wireapp/wire-ios-sync-engine/pull/1408

### Causes

We now correctly report the sync state to `.waitingForWebsocket` but the strategies weren't configured to run in that state.

### Solutions

Allow all strategies to run in `.waitingForWebsocket` if they are already allowed to run during the quick sync.