### PR TITLE
[Fix] deviceClass was incorrectly marked as non-optional

### DIFF
--- a/Sources/Payloads/Payload+Processing.swift
+++ b/Sources/Payloads/Payload+Processing.swift
@@ -22,7 +22,10 @@ extension Payload.UserClient {
     func update(_ client: WireDataModel.UserClient) {
         client.needsToBeUpdatedFromBackend = false
 
-        guard client.user?.isSelfUser == false else { return }
+        guard
+            client.user?.isSelfUser == false,
+            let deviceClass = deviceClass
+        else { return }
 
         client.deviceClass = DeviceClass(rawValue: deviceClass)
     }

--- a/Sources/Payloads/Payload.swift
+++ b/Sources/Payloads/Payload.swift
@@ -62,7 +62,7 @@ enum Payload {
         let creationDate: Date?
         let label: String?
         let location: Location?
-        let deviceClass: String
+        let deviceClass: String?
         let deviceModel: String?
 
         init(id: String,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Message can't be sent in a conversation which contains a client which doesn't have its deviceClass defined.

### Causes

`deviceClass` was annotated as non-optional which causes us to reject the whole response when fetching client metadata which contains a client which doesn't have the device class set.

### Solutions

Mark the `deviceClass` as optional. This will allow us to process all the clients with an assigned device class and do nothing when it's missing.