### PR TITLE
[Fix] Update the conversation security level in the updateEvents decryption method

### DIFF
--- a/Sources/Helpers/EncryptionSessionDirectory+UpdateEvents.swift
+++ b/Sources/Helpers/EncryptionSessionDirectory+UpdateEvents.swift
@@ -71,6 +71,7 @@ extension EncryptionSessionsDirectory {
         if createdNewSession {
             selfUser.selfClient()?.decrementNumberOfRemainingKeys()
             selfUser.selfClient()?.addNewClientToIgnored(senderClient)
+            selfUser.selfClient()?.updateSecurityLevelAfterDiscovering(Set(arrayLiteral: senderClient))
         }
         
         return decryptedEvent


### PR DESCRIPTION
## What's new in this PR?

### Issues
When a new client posts a message in a verified conversation, there is no indication that this is a new client.

### Solutions
Since we have information about the new client when decrypting events, we can also update the security level at this point.(add `updateSecurityLevelAfterDiscovering(...)` method to the event decryption method).


## Notes
https://wearezeta.atlassian.net/browse/SQCORE-539