### PR TITLE
Fix: XCFramework - Linker error related to ZMClientMessage 

### DIFF
--- a/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.swift
+++ b/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.swift
@@ -1,0 +1,49 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMImagePreprocessingTrackerTests {
+    @objc
+    func setUpLinkPreviewMessage() {
+    linkPreviewMessage1 = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: coreDataStack.viewContext)
+    linkPreviewMessage2 = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: coreDataStack.viewContext)
+    linkPreviewMessage3 = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: coreDataStack.viewContext)
+    linkPreviewMessageExcludedByPredicate = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: coreDataStack.viewContext)
+    }
+    
+    @objc
+    func setupSut() {
+        sut = ZMImagePreprocessingTracker(
+            managedObjectContext: coreDataStack.viewContext,
+            imageProcessingQueue: imagePreprocessingQueue,
+            fetch: fetchPredicate,
+            needsProcessingPredicate: needsProcessingPredicate,
+            entityClass: ZMClientMessage.self,
+            preprocessor: (preprocessor as! ZMAssetsPreprocessor))
+    }
+    
+    func testThatItReturnsTheCorrectFetchRequest() {
+        // when
+        let request = sut.fetchRequestForTrackedObjects()
+
+        // then
+        let expectedRequest = ZMClientMessage.sortedFetchRequest(with: fetchPredicate)
+        XCTAssertEqual(request, expectedRequest)
+    }
+}

--- a/Tests/Helpers/NSManagedObjectContext+TestHelpers.h
+++ b/Tests/Helpers/NSManagedObjectContext+TestHelpers.h
@@ -20,6 +20,7 @@
 @import WireDataModel;
 
 
+
 @interface NSManagedObjectContext (TestHelpers)
 
 - (void)performGroupedBlockAndWaitWithReasonableTimeout:(dispatch_block_t)block;

--- a/Tests/Helpers/ZMImagePreprocessingTrackerTests.h
+++ b/Tests/Helpers/ZMImagePreprocessingTrackerTests.h
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@import WireTesting;
+
+@class ZMImagePreprocessingTracker;
+
+@interface ZMImagePreprocessingTrackerTests : ZMTBaseTest
+
+@property (nonatomic) id preprocessor;
+@property (nonatomic) CoreDataStack *coreDataStack;
+@property (nonatomic) NSOperationQueue *imagePreprocessingQueue;
+@property (nonatomic) ZMImagePreprocessingTracker *sut;
+@property (nonatomic) NSPredicate *fetchPredicate;
+@property (nonatomic) NSPredicate *needsProcessingPredicate;
+
+@property (nonatomic)  ZMClientMessage *linkPreviewMessage1;
+@property (nonatomic)  ZMClientMessage *linkPreviewMessage2;
+@property (nonatomic)  ZMClientMessage *linkPreviewMessage3;
+@property (nonatomic)  ZMClientMessage *linkPreviewMessageExcludedByPredicate;
+
+@end

--- a/Tests/Resources/Bridging-Header.h
+++ b/Tests/Resources/Bridging-Header.h
@@ -19,5 +19,5 @@
 #import "MockEntity.h"
 #import "MockEntity2.h"
 #import "MockModelObjectContextFactory.h"
-
-
+#import "ZMImagePreprocessingTrackerTests.h"
+#import "ZMImagePreprocessingTracker.h"

--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		878B823620A1D19D007455CA /* HTMLString.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 878B823320A1D080007455CA /* HTMLString.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8792F55721AD944100795027 /* UserPropertyRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792F55621AD944100795027 /* UserPropertyRequestStrategy.swift */; };
 		87F7288521AFF37D000ED371 /* UserPropertyRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F7288421AFF37D000ED371 /* UserPropertyRequestStrategyTests.swift */; };
+		A90C56E62685C20E00F1007B /* ZMImagePreprocessingTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90C56E52685C20E00F1007B /* ZMImagePreprocessingTrackerTests.swift */; };
 		BF1F52C61ECC74E5002FB553 /* Array+RequestGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F52C51ECC74E5002FB553 /* Array+RequestGenerator.swift */; };
 		BF7D9BE11D8C351900949267 /* WireRequestStrategy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1669016A1D707509000FE4AF /* WireRequestStrategy.framework */; };
 		BF7D9BEA1D8C353A00949267 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF66512F1D8C2ED50074F367 /* OCMock.framework */; };
@@ -359,6 +360,8 @@
 		878B823320A1D080007455CA /* HTMLString.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HTMLString.framework; path = Carthage/Build/iOS/HTMLString.framework; sourceTree = "<group>"; };
 		8792F55621AD944100795027 /* UserPropertyRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPropertyRequestStrategy.swift; sourceTree = "<group>"; };
 		87F7288421AFF37D000ED371 /* UserPropertyRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPropertyRequestStrategyTests.swift; sourceTree = "<group>"; };
+		A90C56E52685C20E00F1007B /* ZMImagePreprocessingTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMImagePreprocessingTrackerTests.swift; sourceTree = "<group>"; };
+		A90C56EB2685C23400F1007B /* ZMImagePreprocessingTrackerTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMImagePreprocessingTrackerTests.h; sourceTree = "<group>"; };
 		BF1F52C51ECC74E5002FB553 /* Array+RequestGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+RequestGenerator.swift"; sourceTree = "<group>"; };
 		BF66512F1D8C2ED50074F367 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Carthage/Build/iOS/OCMock.framework; sourceTree = "<group>"; };
 		BF6651311D8C2ED50074F367 /* PINCache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PINCache.framework; path = Carthage/Build/iOS/PINCache.framework; sourceTree = "<group>"; };
@@ -512,6 +515,7 @@
 		1621D2211D75AB2D007108C2 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				A90C56EB2685C23400F1007B /* ZMImagePreprocessingTrackerTests.h */,
 				F18401F82073C2E600E9F4CC /* MessagingTest+Encryption.swift */,
 				06D06519256340470057836B /* FeatureControllerTest.swift */,
 				F18401F62073C2E500E9F4CC /* MessagingTestBase.swift */,
@@ -536,6 +540,7 @@
 				16229483221EBB8000A98679 /* ZMImagePreprocessingTracker.m */,
 				16229484221EBB8000A98679 /* ZMImagePreprocessingTracker+Testing.h */,
 				16229485221EBB8000A98679 /* ZMImagePreprocessingTrackerTests.m */,
+				A90C56E52685C20E00F1007B /* ZMImagePreprocessingTrackerTests.swift */,
 			);
 			path = "Image Preprocessing";
 			sourceTree = "<group>";
@@ -1295,6 +1300,7 @@
 				1621D2661D75C755007108C2 /* ZMLocallyModifiedObjectSyncStatusTests.m in Sources */,
 				F18401FE2073C2EA00E9F4CC /* MessagingTest+Encryption.swift in Sources */,
 				16A86B4622A5485E00A674F8 /* IdentifierObjectSyncTests.swift in Sources */,
+				A90C56E62685C20E00F1007B /* ZMImagePreprocessingTrackerTests.swift in Sources */,
 				F18401DE2073C25900E9F4CC /* ClientMessageTranscoderTests.swift in Sources */,
 				F19561FB202A13C3005347C0 /* ZMSyncOperationSetTests.m in Sources */,
 				F18401E92073C26700E9F4CC /* AvailabilityRequestStrategyTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues
When building test using XCFramework, link error occurs:
`Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$__TtC13WireDataModel15ZMClientMessage", referenced from:
      objc-class-ref in ZMImagePreprocessingTrackerTests.o
ld: symbol(s) not found for architecture x86_64`

### Causes

Unknown

### Solutions

Convert code contains `ZMClientMessage`  in `ZMImagePreprocessingTrackerTests` to Swift.

