### PR TITLE
[Feature] Support for disabling federation

### DIFF
--- a/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -38,7 +38,8 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
     let applicationStatus: ApplicationStatus
     let context: NSManagedObjectContext
     var onRequestScheduledHandler: OnRequestScheduledHandler?
-    var isFederationEndpointAvailable = true
+    
+    public var isFederationEndpointAvailable = true
 
     public init(context: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         self.context = context

--- a/Sources/Protocols/SharedProtocols.swift
+++ b/Sources/Protocols/SharedProtocols.swift
@@ -20,13 +20,22 @@
 import Foundation
 
 
-@objc public protocol ClientRegistrationDelegate : NSObjectProtocol  {
+@objc public protocol ClientRegistrationDelegate: NSObjectProtocol  {
 
     /// Returns true if the client is registered
     var clientIsReadyForRequests : Bool { get }
     
     /// Notify that the current client was deleted remotely
     func didDetectCurrentClientDeletion()
+
+}
+
+/// Request strategies which adopt this protocol declare that they can will talk to federation aware endpoints.
+@objc public protocol FederationAware: NSObjectProtocol {
+
+    /// If `true` the request strategy will talk to federation aware endpoints, otherwise it will
+    // fallback to legacy endpoints.
+    var useFederationEndpoint: Bool { get set }
 
 }
 

--- a/Sources/Protocols/SharedProtocols.swift
+++ b/Sources/Protocols/SharedProtocols.swift
@@ -30,7 +30,7 @@ import Foundation
 
 }
 
-/// Request strategies which adopt this protocol declare that they can will talk to federation aware endpoints.
+/// Request strategies which adopt this protocol declare that they can talk to federation aware endpoints.
 @objc public protocol FederationAware: NSObjectProtocol {
 
     /// If `true` the request strategy will talk to federation aware endpoints, otherwise it will

--- a/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -24,10 +24,19 @@ import Foundation
 /// upload the asset, receive the asset ID in the response, manually add it to the genericMessage and
 /// send it using the `/messages` endpoint like any other message. This is an additional step required
 /// as the fan-out was previously done by the backend when uploading a v2 asset.
-public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource {
+public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource, FederationAware {
 
     let insertedObjectSync: InsertedObjectSync<AssetClientMessageRequestStrategy>
     let messageSync: ProteusMessageSync<ZMAssetClientMessage>
+
+    public var useFederationEndpoint: Bool {
+        set {
+            messageSync.isFederationEndpointAvailable = newValue
+        }
+        get {
+            messageSync.isFederationEndpointAvailable
+        }
+    }
 
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
 

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
@@ -18,10 +18,19 @@
 
 import Foundation
 
-public class LinkPreviewUpdateRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource {
+public class LinkPreviewUpdateRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource, FederationAware {
 
     let modifiedKeysSync: ModifiedKeyObjectSync<LinkPreviewUpdateRequestStrategy>
     let messageSync: ProteusMessageSync<ZMClientMessage>
+
+    public var useFederationEndpoint: Bool {
+        set {
+            messageSync.isFederationEndpointAvailable = newValue
+        }
+        get {
+            messageSync.isFederationEndpointAvailable
+        }
+    }
 
     static func linkPreviewIsUploadedPredicate(context: NSManagedObjectContext) -> NSPredicate {
         return NSPredicate(format: "%K == %@ AND %K == %d",

--- a/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
@@ -18,13 +18,22 @@
 
 import Foundation
 
-public class ClientMessageRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource {
+public class ClientMessageRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource, FederationAware {
 
     let insertedObjectSync: InsertedObjectSync<ClientMessageRequestStrategy>
     let messageSync: ProteusMessageSync<ZMClientMessage>
     let messageExpirationTimer: MessageExpirationTimer
     let linkAttachmentsPreprocessor: LinkAttachmentsPreprocessor
     let localNotificationDispatcher: PushMessageHandler
+
+    public var useFederationEndpoint: Bool {
+        set {
+            messageSync.isFederationEndpointAvailable = newValue
+        }
+        get {
+            messageSync.isFederationEndpointAvailable
+        }
+    }
 
     static func shouldBeSentPredicate(context: NSManagedObjectContext) -> NSPredicate {
         let notDelivered = NSPredicate(format: "%K == FALSE", DeliveredKey)

--- a/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
+++ b/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
@@ -44,9 +44,18 @@ extension ZMUpdateEvent {
 }
 
 @objcMembers
-public final class DeliveryReceiptRequestStrategy: AbstractRequestStrategy {
+public final class DeliveryReceiptRequestStrategy: AbstractRequestStrategy, FederationAware {
     
     private let messageSync: ProteusMessageSync<GenericMessageEntity>
+
+    public var useFederationEndpoint: Bool {
+        set {
+            messageSync.isFederationEndpointAvailable = newValue
+        }
+        get {
+            messageSync.isFederationEndpointAvailable
+        }
+    }
     
     // MARK: - Init
     

--- a/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
@@ -71,6 +71,21 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
             XCTAssertEqual(request.path, "/conversations/\(conversationDomain)/\(conversationID)/proteus/messages")
         }
     }
+
+    func testThatRequestIsGenerated_WhenProcessingEventWhichNeedsDeliveryReceipt_With_FederationEndpointDisabled() throws {
+        try syncMOC.performGroupedAndWait { moc in
+            let conversationID = self.oneToOneConversation.remoteIdentifier!.transportString()
+            let event = self.createTextUpdateEvent(from: self.otherUser, in: self.oneToOneConversation)
+            self.sut.useFederationEndpoint = false
+
+            // when
+            self.sut.processEventsWhileInBackground([event])
+
+            // then
+            let request = try XCTUnwrap(self.sut.nextRequest())
+            XCTAssertEqual(request.path, "/conversations/\(conversationID)/otr/messages")
+        }
+    }
         
     // MARK: Delivery receipt creation
     

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -34,7 +34,7 @@ public let ZMNeedsToUpdateUserClientsNotificationUserObjectIDKey = "userObjectID
 }
 
 @objc
-public final class FetchingClientRequestStrategy : AbstractRequestStrategy {
+public final class FetchingClientRequestStrategy: AbstractRequestStrategy {
 
     fileprivate static let needsToUpdateUserClientsNotificationName = Notification.Name("ZMNeedsToUpdateUserClientsNotification")
 

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -21,11 +21,20 @@ import Foundation
 
 /// Register new client, update it with new keys, deletes clients.
 @objc
-public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUpstreamTranscoder, ZMContextChangeTrackerSource {
+public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUpstreamTranscoder, ZMContextChangeTrackerSource, FederationAware {
 
     var isFederationEndpointAvailable: Bool = true
     fileprivate(set) var modifiedSync: ZMUpstreamModifiedObjectSync! = nil
     public var requestsFactory = MissingClientsRequestFactory()
+
+    public var useFederationEndpoint: Bool {
+        set {
+            isFederationEndpointAvailable = newValue
+        }
+        get {
+            isFederationEndpointAvailable
+        }
+    }
     
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)

--- a/Sources/Request Strategies/User Clients/ResetSessionRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/ResetSessionRequestStrategy.swift
@@ -18,10 +18,19 @@
 
 import Foundation
 
-public class ResetSessionRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource {
+public class ResetSessionRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource, FederationAware {
     
     fileprivate let keyPathSync: KeyPathObjectSync<ResetSessionRequestStrategy>
     fileprivate let messageSync: ProteusMessageSync<GenericMessageEntity>
+
+    public var useFederationEndpoint: Bool {
+        set {
+            messageSync.isFederationEndpointAvailable = newValue
+        }
+        get {
+            messageSync.isFederationEndpointAvailable
+        }
+    }
 
     public init(managedObjectContext: NSManagedObjectContext,
                 applicationStatus: ApplicationStatus,

--- a/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -43,7 +43,7 @@ extension Collection where Element == ZMUser {
 /// - During the `.fetchingUsers` slow sync phase.
 /// - When a user is marked as `needsToBeUpdatedFromBackend`.
 ///
-public class UserProfileRequestStrategy: AbstractRequestStrategy, IdentifierObjectSyncDelegate {
+public class UserProfileRequestStrategy: AbstractRequestStrategy, IdentifierObjectSyncDelegate, FederationAware {
 
     var isFetchingAllConnectedUsers: Bool = false
     let syncProgress: SyncProgress
@@ -53,6 +53,15 @@ public class UserProfileRequestStrategy: AbstractRequestStrategy, IdentifierObje
 
     let userProfileByIDTranscoder: UserProfileByIDTranscoder
     let userProfileByQualifiedIDTranscoder: UserProfileByQualifiedIDTranscoder
+
+    public var useFederationEndpoint: Bool {
+        set {
+            userProfileByQualifiedIDTranscoder.isAvailable = newValue
+        }
+        get {
+            userProfileByQualifiedIDTranscoder.isAvailable
+        }
+    }
 
     public init(managedObjectContext: NSManagedObjectContext,
          applicationStatus: ApplicationStatus,

--- a/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
@@ -183,6 +183,22 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
 
     // MARK: - Response processing
 
+    func testThatFallbacksToLegacyEndpoint_WhenFederatedEndpointIsDisabled() {
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            self.sut.useFederationEndpoint = false
+            self.otherUser.domain = "example.com"
+            self.otherUser.needsToBeUpdatedFromBackend = true
+            self.sut.objectsDidChange(Set([self.otherUser]))
+
+            // when
+            let request = self.sut.nextRequest()!
+
+            // then
+            XCTAssertEqual(request.path, "/users?ids=\(self.otherUser.remoteIdentifier.transportString())")
+        }
+    }
+
     func testThatFallbacksToLegacyEndpoint_WhenFederatedEndpointIsNotAvailable() {
         syncMOC.performGroupedBlockAndWait {
             // given


### PR DESCRIPTION
## What's new in this PR?

Introduce a `FederationAware` protocol which can be implemented by request strategies to declare that they interacting with federation endpoints and provide an option to disable their usage.