### PR TITLE
[Fix] Asset uploading when multiple assets are needed

### DIFF
--- a/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
@@ -148,9 +148,11 @@ extension AssetV3UploadRequestStrategy: ZMUpstreamTranscoder {
         
         if message.processingState == .done {
             message.updateTransferState(.uploaded, synchronize: false)
+            return false
+        } else {
+            // There are more assets to upload
+            return true
         }
-        
-        return false
     }
     
     public func shouldRetryToSyncAfterFailed(toUpdate managedObject: ZMManagedObject,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Asset uploading wouldn't finish when multiple assets were involved, for example video file with a preview image.

### Causes

In previous refactoring of `AssetV3UploadRequestStrategy` changed `updateUpdatedObject()` to always return `false`, meaning it does not need any do any additional requests, which isn't true when there are multiple assets involved.

### Solutions

Return `true` in case the `processingState` isn't `.done`.
