### PR TITLE
[Fix] User profile download failing because the query string is too big

### DIFF
--- a/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -225,7 +225,7 @@ class UserProfileByIDTranscoder: IdentifierObjectSyncTranscoder {
 
     public typealias T = UUID
 
-    var fetchLimit: Int = 500
+    var fetchLimit: Int =  1600 / 25 // UUID as string is 24 + 1 for the comma
     var isAvailable: Bool = true
 
     let context: NSManagedObjectContext


### PR DESCRIPTION
## What's new in this PR?

### Issues

For large teams / accounts the user profile download would fail.

### Causes

The backend responded with an error because the query string was too big.

### Solutions

Set the same limit as in the old `ZMUserTranscoder` for how many users we download per request.