### PR TITLE
[Fix] Duplicate messages being sent

### DIFF
--- a/Sources/Other Syncs/DependencyEntitySync.swift
+++ b/Sources/Other Syncs/DependencyEntitySync.swift
@@ -69,7 +69,7 @@ class DependencyEntitySync<Transcoder : EntityTranscoder> : NSObject, ZMContextC
                 if let newDependency = newDependency, newDependency != object {
                     entitiesWithDependencies.add(dependency: newDependency, for: entity)
                 } else if newDependency == nil {
-                    entitiesWithDependencies.remove(dependency: object, for: entity)
+                    entitiesWithDependencies.removeAllDependencies(for: entity)
                     entitiesWithoutDependencies.append(entity)
                 }
             }

--- a/Sources/Other Syncs/DependencyEntitySyncTests.swift
+++ b/Sources/Other Syncs/DependencyEntitySyncTests.swift
@@ -21,7 +21,7 @@ import WireTesting
 
 @testable import WireRequestStrategy
 
-class MockDependencyEntity : DependencyEntity, Hashable {
+class MockDependencyEntity: DependencyEntity, Hashable {
     public var expirationDate: Date?
     public var isExpired: Bool = false
     fileprivate let uuid = UUID()
@@ -41,9 +41,9 @@ func ==(lhs: MockDependencyEntity, rhs: MockDependencyEntity) -> Bool {
     return lhs === rhs
 }
 
-class MockEntityTranscoder : EntityTranscoder {
-    
-    var didCallRequestForEntity : Bool = false
+class MockEntityTranscoder: EntityTranscoder {
+
+    var didCallRequestForEntityCount: Int = 0
     var didCallRequestForEntityDidCompleteWithResponse : Bool = false
     var didCallShouldTryToResendAfterFailure : Bool = false
     
@@ -56,7 +56,7 @@ class MockEntityTranscoder : EntityTranscoder {
     
     func request(forEntity entity: MockDependencyEntity) -> ZMTransportRequest? {
         requestForEntityExpectation?.fulfill()
-        didCallRequestForEntity = true
+        didCallRequestForEntityCount += 1
         return generatedRequest
     }
     
@@ -73,7 +73,7 @@ class MockEntityTranscoder : EntityTranscoder {
     
 }
 
-class DependencyEntitySyncTests : ZMTBaseTest {
+class DependencyEntitySyncTests: ZMTBaseTest {
 
     var context : NSManagedObjectContext!
     var mockTranscoder = MockEntityTranscoder()
@@ -103,7 +103,7 @@ class DependencyEntitySyncTests : ZMTBaseTest {
         _ = sut.nextRequest()
         
         // then
-        XCTAssertTrue(mockTranscoder.didCallRequestForEntity)
+        XCTAssertEqual(mockTranscoder.didCallRequestForEntityCount, 1)
     }
     
     func testThatTranscoderIsNotAskedToCreateRequest_whenEntityHasDependencies() {
@@ -117,7 +117,7 @@ class DependencyEntitySyncTests : ZMTBaseTest {
         _ = sut.nextRequest()
         
         // then
-        XCTAssertFalse(mockTranscoder.didCallRequestForEntity)
+        XCTAssertEqual(mockTranscoder.didCallRequestForEntityCount, 0)
     }
     
     func testThatEntityIsExpired_whenExpiringEntitiesWithDependencies() {
@@ -146,7 +146,7 @@ class DependencyEntitySyncTests : ZMTBaseTest {
         _ = sut.nextRequest()
         
         // then
-        XCTAssertFalse(mockTranscoder.didCallRequestForEntity)
+        XCTAssertEqual(mockTranscoder.didCallRequestForEntityCount, 0)
     }
     
     func testThatTranscoderIsNotAskedToCreateRequest_whenEntityHasExpired() {
@@ -160,7 +160,7 @@ class DependencyEntitySyncTests : ZMTBaseTest {
         _ = sut.nextRequest()
         
         // then
-        XCTAssertFalse(mockTranscoder.didCallRequestForEntity)
+        XCTAssertEqual(mockTranscoder.didCallRequestForEntityCount, 0)
     }
     
     func testThatTranscoderIsAskedToCreateRequest_whenEntityHasNoDependenciesAfterAnUpdate() {
@@ -176,7 +176,27 @@ class DependencyEntitySyncTests : ZMTBaseTest {
         _ = sut.nextRequest()
         
         // then
-         XCTAssertTrue(mockTranscoder.didCallRequestForEntity)
+        XCTAssertEqual(mockTranscoder.didCallRequestForEntityCount, 1)
+    }
+
+    func testThatTranscoderIsAskedToCreateRequestOnlyOnce_whenEntityHadMultipleDependencies() {
+
+        // given
+        let entity = MockDependencyEntity()
+        entity.dependentObjectNeedingUpdateBeforeProcessing = dependency
+        sut.synchronize(entity: entity)
+
+        entity.dependentObjectNeedingUpdateBeforeProcessing = anotherDependency
+        sut.objectsDidChange(Set(arrayLiteral: dependency))
+
+        // when
+        entity.dependentObjectNeedingUpdateBeforeProcessing = nil
+        sut.objectsDidChange(Set(arrayLiteral: dependency, anotherDependency))
+        _ = sut.nextRequest()
+        _ = sut.nextRequest()
+
+        // then
+        XCTAssertEqual(mockTranscoder.didCallRequestForEntityCount, 1)
     }
     
     // Mark - Response handling
@@ -229,13 +249,13 @@ class DependencyEntitySyncTests : ZMTBaseTest {
         request?.complete(with: response)
         
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5)) // wait for response to fail
-        mockTranscoder.didCallRequestForEntity = false //reset since we expect it be called again
+        mockTranscoder.didCallRequestForEntityCount = 0 // reset since we expect it be called again
         
         // when
         _ = sut.nextRequest()
         
         // then
-        XCTAssertTrue(mockTranscoder.didCallRequestForEntity)
+        XCTAssertEqual(mockTranscoder.didCallRequestForEntityCount, 1)
     }
     
 }

--- a/Sources/Other Syncs/DependentObjects.swift
+++ b/Sources/Other Syncs/DependentObjects.swift
@@ -68,6 +68,14 @@ public class DependentObjects<Object: Hashable, Dependency: Hashable> {
         self.updateDependents(dependent: dependent, removing: dependency)
         self.updateDependencies(dependency: dependency, removing: dependent)
     }
+
+    public func removeAllDependencies(for dependent: Object) {
+        guard let dependencies = dependentsToDependencies[dependent] else { return }
+
+        for dependency in dependencies {
+            remove(dependency: dependency, for: dependent)
+        }
+    }
     
     private func updateDependencies(dependency: Dependency, removing dependent: Object) {
         guard let currentSet = dependenciesToDependents[dependency] else { return }

--- a/Sources/Other Syncs/DependentObjectsTests.swift
+++ b/Sources/Other Syncs/DependentObjectsTests.swift
@@ -128,6 +128,18 @@ class DependentObjectsTests: ZMTBaseTest {
         }
         XCTAssertEqual(Set([self.messageB!, self.messageC!]), Set(result))
     }
+
+    func testThatItRemovesAllObjects() {
+        // GIVEN
+        self.sut.add(dependency: self.conversation1!, for: self.messageA!)
+        self.sut.add(dependency: self.conversation2!, for: self.messageA!)
+
+        // WHEN
+        sut.removeAllDependencies(for: messageA)
+
+        // THEN
+        XCTAssertTrue(sut.dependencies(for: messageA).isEmpty)
+    }
     
     func testThatItEnumeratesObjectsForTheCorrectDependency() {
         // GIVEN


### PR DESCRIPTION
## What's new in this PR?

### Issues

It been observed that messages were sometimes sent multiple times.

### Causes

In the case when a message has multiple dependencies which needs to be resolved before it can be sent it would be added to the list of "messages to send" once per dependency.

### Solutions

When a message has resolved its dependencies, clear all dependencies immediately.