### PR TITLE
Fix: xcode 13 String Format Specifiers %u does not compile

### DIFF
--- a/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.m
+++ b/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.m
@@ -101,12 +101,6 @@
 
 @implementation ZMImagePreprocessingTrackerTests (OutstandingItems)
 
-- (void)testThatItHasNoOutstandingItems;
-{
-    XCTAssertFalse(self.sut.hasOutstandingItems, @"%u / %u",
-                   (unsigned) self.sut.imageOwnersThatNeedPreprocessing, (unsigned) self.sut.imageOwnersBeingPreprocessed);
-}
-
 - (void)testThatItHasOutstandingItemsWhenItemsAreAdded
 {
     // given
@@ -161,8 +155,7 @@
     XCTAssert([self waitForAllGroupsToBeEmptyWithTimeout:0.3]);
     
     // then
-    XCTAssertFalse(self.sut.hasOutstandingItems, @"%u / %u",
-                   (unsigned) self.sut.imageOwnersThatNeedPreprocessing, (unsigned) self.sut.imageOwnersBeingPreprocessed);
+    XCTAssertFalse(self.sut.hasOutstandingItems);
 }
 
 - (void)testThatItHasNoOutstandingItemsWhenItemsNotMatchingThePredicateChange

--- a/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.m
+++ b/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.m
@@ -155,7 +155,7 @@
     XCTAssert([self waitForAllGroupsToBeEmptyWithTimeout:0.3]);
     
     // then
-    XCTAssertFalse(self.sut.hasOutstandingItems);
+    [self assertHasOutstandingItems];
 }
 
 - (void)testThatItHasNoOutstandingItemsWhenItemsNotMatchingThePredicateChange

--- a/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.swift
+++ b/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.swift
@@ -47,9 +47,15 @@ extension ZMImagePreprocessingTrackerTests {
         XCTAssertEqual(request, expectedRequest)
     }
     
-    func testThatItHasNoOutstandingItems() {
+    @objc
+    func assertHasOutstandingItems() {
         XCTAssertFalse(
             sut.hasOutstandingItems,
-            "\(sut.imageOwnersThatNeedPreprocessing) / \(sut.imageOwnersBeingPreprocessed)")
+            "\(sut.imageOwnersThatNeedPreprocessing.description) / \(sut.imageOwnersBeingPreprocessed.description)")
+
+    }
+    
+    func testThatItHasNoOutstandingItems() {
+        assertHasOutstandingItems()
     }
 }

--- a/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.swift
+++ b/Sources/Image Preprocessing/ZMImagePreprocessingTrackerTests.swift
@@ -46,4 +46,10 @@ extension ZMImagePreprocessingTrackerTests {
         let expectedRequest = ZMClientMessage.sortedFetchRequest(with: fetchPredicate)
         XCTAssertEqual(request, expectedRequest)
     }
+    
+    func testThatItHasNoOutstandingItems() {
+        XCTAssertFalse(
+            sut.hasOutstandingItems,
+            "\(sut.imageOwnersThatNeedPreprocessing) / \(sut.imageOwnersBeingPreprocessed)")
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

Fix the compiler error on Xcode 13 that `%u` is not allowed for `unsigned` type. ( `imageOwnersThatNeedPreprocessing` is `NSMutableOrderedSet` and should not be casted to unsigned int)