### PR TITLE
[Fix] 1-1 Calls sometimes not connecting 

### DIFF
--- a/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -64,6 +64,7 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
 
     public func sync(_ message: Message, completion: @escaping EntitySyncHandler) {
         dependencySync.synchronize(entity: message, completion: completion)
+        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
 
     public func expireMessages(withDependency dependency: NSObject) {

--- a/Sources/Object Syncs/Helpers/ProteusMessageSyncTests.swift
+++ b/Sources/Object Syncs/Helpers/ProteusMessageSyncTests.swift
@@ -40,6 +40,22 @@ class ProteusMessageSyncTests: MessagingTestBase {
         }
     }
 
+    func testThatItNotifiesThatNewRequestsAreAvailable_WhenSynchronizingMessage() {
+        // given
+        let message = MockOTREntity(conversation: self.groupConversation, context: self.syncMOC)
+
+        // expect
+        expectation(forNotification: Notification.Name("RequestAvailableNotification"),
+                    object: nil,
+                    handler: nil)
+
+        // when
+        sut.sync(message) { (_, _) in }
+
+        // then
+        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+    }
+
     func testThatItCallsSyncCompletionHandler_WhenResponseIsSuccessfull() throws {
         syncMOC.performGroupedBlockAndWait { [self] in
             // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's been observed that 1-1 Calls are sometimes not connecting.

### Causes

If the call message didn't need any further requests for establishing sessions, the SETUP message wouldn't be sent until another event occurred in the application. This behaviour comes from the fact that calling messages are not persisted in Core Data which is what normally triggers the operation loop to send new requests.

### Solutions

Always explicitly tell the operation loop that there's new requests available after scheduling a message to be sent.

## Notes

This bug was introduced by https://github.com/wireapp/wire-ios-request-strategy/pull/361
