### PR TITLE
[Fix] Don't crash when to field is nil due to connection being cancelled

### DIFF
--- a/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -105,7 +105,7 @@ public class UserProfileRequestStrategy: AbstractRequestStrategy, IdentifierObje
         let fetchRequest = NSFetchRequest<ZMConnection>(entityName: ZMConnection.entityName())
         let connections = managedObjectContext.fetchOrAssert(request: fetchRequest)
 
-        return Set(connections.map(\.to))
+        return Set(connections.compactMap(\.to))
     }
 
     public func didFailToSyncAllObjects() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would crash when syncing the user profiles of your connections.

### Causes

If a connection is cancelled the `to` field is nulled out and `connections.map(\.to)` would crash due to force unwrapping.

### Solutions

Use `compactMap` instead.