### PR TITLE
Fix: messages fails to send after accepting connection request

### DIFF
--- a/Sources/Payloads/Payload+Processing.swift
+++ b/Sources/Payloads/Payload+Processing.swift
@@ -502,12 +502,13 @@ extension Payload.Conversation {
         conversation.remoteIdentifier = conversationID
         conversation.domain = qualifiedID?.domain
         conversation.conversationType = conversationType
-        conversation.needsToBeUpdatedFromBackend = false
 
         updateMetadata(for: conversation, context: context)
         updateMembers(for: conversation, context: context)
         updateConversationTimestamps(for: conversation, serverTimestamp: serverTimestamp)
         updateConversationStatus(for: conversation)
+
+        conversation.needsToBeUpdatedFromBackend = false
     }
 
     func updateOrCreateSelfConversation(in context: NSManagedObjectContext,

--- a/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -629,6 +629,8 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
     func didReceive(response: ZMTransportResponse, for identifiers: Set<QualifiedID>) {
 
         guard response.result != .permanentError else {
+            markConversationsAsFetched(identifiers)
+
             if response.httpStatus == 404 {
                 deleteConversations(identifiers)
                 return
@@ -638,8 +640,6 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
                 removeSelfUser(identifiers)
                 return
             }
-
-            markConversationsAsFetched(identifiers)
             return
         }
 
@@ -661,6 +661,7 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
                 let conversation = ZMConversation.fetch(with: qualifiedID.uuid, domain: qualifiedID.domain, in: context),
                 conversation.conversationType == .group
             else {
+
                 continue
             }
             context.delete(conversation)
@@ -678,7 +679,6 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
             }
             let selfUser = ZMUser.selfUser(in: context)
             conversation.removeParticipantAndUpdateConversationState(user: selfUser, initiatingUser: selfUser)
-            conversation.needsToBeUpdatedFromBackend = false
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

messages fails to send after accepting connection request.

### Causes

Message doesn't get sent because they are waiting for the conversations to be updated from the BE which never happens. It never happens because `needsToBeUpdatedFromBackend` was not being reset to `false` in some cases when processing a conversation response.

### Solutions

1. When updating a new 1:1 conversation `needsToBeUpdatedFromBackend` was set to true when `updateMembers()` was called because the self user was added. Move  `needsToBeUpdatedFromBackend = false` to end of the function body.

2. When fetching a pending 1:1 conversation in federated context BE will return 404 for a short moment. This path was missing a `needsToBeUpdatedFromBackend = false`.