### PR TITLE
Fix: xcode13 warning - Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead

### DIFF
--- a/Sources/Object Syncs/Helpers/IdentifierObjectSync.swift
+++ b/Sources/Object Syncs/Helpers/IdentifierObjectSync.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// Delegate protocol which the user of the IdentifierObjectSync class should implement.
 
-public protocol IdentifierObjectSyncTranscoder: class {
+public protocol IdentifierObjectSyncTranscoder: AnyObject {
     associatedtype T: Hashable
     
     var fetchLimit: Int { get }
@@ -33,7 +33,7 @@ public protocol IdentifierObjectSyncTranscoder: class {
     
 }
 
-public protocol IdentifierObjectSyncDelegate: class {
+public protocol IdentifierObjectSyncDelegate: AnyObject {
 
     func didFinishSyncingAllObjects()
     func didFailToSyncAllObjects()

--- a/Sources/Other Syncs/DependencyEntitySync.swift
+++ b/Sources/Other Syncs/DependencyEntitySync.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-@objc public protocol DependencyEntity: class {
+@objc public protocol DependencyEntity: AnyObject {
     @objc var dependentObjectNeedingUpdateBeforeProcessing : NSObject? { get }
     @objc var isExpired: Bool { get }
     @objc func expire()

--- a/Sources/Protocols/ApplicationStatus.swift
+++ b/Sources/Protocols/ApplicationStatus.swift
@@ -34,7 +34,7 @@ public enum OperationState : UInt {
 }
 
 @objc(ZMApplicationStatus)
-public protocol ApplicationStatus : class {
+public protocol ApplicationStatus : AnyObject {
     var synchronizationState : SynchronizationState { get }
     var operationState : OperationState { get }    
     var clientRegistrationDelegate : ClientRegistrationDelegate { get }


### PR DESCRIPTION
## What's new in this PR?

Replace all protocol extends `class` with `AnyObject`