### PR TITLE
Fix: Sending via share extension doesn't work

### DIFF
--- a/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -39,7 +39,7 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
     let context: NSManagedObjectContext
     var onRequestScheduledHandler: OnRequestScheduledHandler?
     
-    public var isFederationEndpointAvailable = true
+    public var isFederationEndpointAvailable = false
 
     public init(context: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         self.context = context

--- a/Sources/Object Syncs/Helpers/ProteusMessageSyncTests.swift
+++ b/Sources/Object Syncs/Helpers/ProteusMessageSyncTests.swift
@@ -32,6 +32,7 @@ class ProteusMessageSyncTests: MessagingTestBase {
 
         mockApplicationStatus = MockApplicationStatus()
         sut = ProteusMessageSync<MockOTREntity>(context: syncMOC, applicationStatus: mockApplicationStatus)
+        sut.isFederationEndpointAvailable = true
 
         syncMOC.performGroupedBlockAndWait { [self] in
             otherUser.domain = domain

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
@@ -31,6 +31,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
             self.applicationStatus = MockApplicationStatus()
             self.applicationStatus.mockSynchronizationState = .online
             self.sut = LinkPreviewUpdateRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: self.applicationStatus)
+            self.sut.useFederationEndpoint = true
         }
     }
 

--- a/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
@@ -36,6 +36,7 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
         sut = DeliveryReceiptRequestStrategy(managedObjectContext: syncMOC,
                                              applicationStatus: mockApplicationStatus,
                                              clientRegistrationDelegate: mockClientRegistrationStatus)
+        sut.useFederationEndpoint = true
         
         syncMOC.performGroupedBlockAndWait {
             let user = ZMUser.insertNewObject(in: self.syncMOC)

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -23,7 +23,7 @@ import Foundation
 @objc
 public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUpstreamTranscoder, ZMContextChangeTrackerSource, FederationAware {
 
-    var isFederationEndpointAvailable: Bool = true
+    var isFederationEndpointAvailable: Bool = false
     fileprivate(set) var modifiedSync: ZMUpstreamModifiedObjectSync! = nil
     public var requestsFactory = MissingClientsRequestFactory()
 

--- a/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
@@ -35,6 +35,7 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
         sut = ResetSessionRequestStrategy(managedObjectContext: self.syncMOC,
                                     applicationStatus: mockApplicationStatus,
                                     clientRegistrationDelegate: mockApplicationStatus.clientRegistrationDelegate)
+        sut.useFederationEndpoint = true
     }
     
     override func tearDown() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

 Sending via share extension doesn't work

### Causes

Share extension attempts to use federation endpoint which require domains but they aren't available.

### Solutions

Disable federation endpoints by default.

## Notes

Future-work: respect the federation feature flag in the share extension.
