### PR TITLE
refactor: Replace IdentifierObjectSync with ObjectSync (part1) SQCORE-1155 

### DIFF
--- a/Sources/Object Syncs/ObjectSync.swift
+++ b/Sources/Object Syncs/ObjectSync.swift
@@ -1,0 +1,309 @@
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+protocol Source {
+    associatedtype Object
+
+    typealias OnPublish = (_ object: Object) -> Void
+    typealias OnUnpublish = (_ object: Object) -> Void
+
+    var onPublish: OnPublish? { get set }
+    var onUnpublish: OnUnpublish? { get set }
+}
+
+extension Source {
+
+    mutating func onPublish(_ onPublish: @escaping OnPublish) {
+        self.onPublish = onPublish
+    }
+
+    mutating func onUnpublish(_ onUnpublish: @escaping OnUnpublish) {
+        self.onUnpublish = onUnpublish
+    }
+
+    func publish(_ object: Object) {
+        onPublish?(object)
+    }
+
+    func unpublish(_ object: Object) {
+        onUnpublish?(object)
+    }
+
+}
+
+protocol Filter {
+    associatedtype Object
+
+    func isIncluded(_ object: Object) -> Bool
+}
+
+protocol Transcoder {
+    associatedtype Object: Hashable
+
+    var fetchLimit: Int { get }
+    var supportBatchRequests: Bool { get }
+
+    func requestFor(_ object: Object) -> ZMTransportRequest?
+    func requestFor(_ objects: Set<Object>) -> ZMTransportRequest?
+
+    func handleResponse(response: ZMTransportResponse, for object: Object)
+    func handleResponse(response: ZMTransportResponse, for objects: Set<Object>)
+}
+
+extension Transcoder {
+
+    var fetchLimit: Int {
+        1
+    }
+
+    var supportBatchRequests: Bool {
+        return fetchLimit > 1
+    }
+
+    func requestFor(_ objects: Set<Object>) -> ZMTransportRequest? {
+        requestFor(objects.first!)
+    }
+
+    func handleResponse(response: ZMTransportResponse, for objects: Set<Object>) {
+        handleResponse(response: response, for: objects.first!)
+    }
+
+}
+
+struct AnyFilter<P> {
+    typealias Object = P
+
+    let isIncluded: (P) -> Bool
+}
+
+struct KeyPathFilter<Object: ZMManagedObject>: Filter {
+    typealias Object = Object
+
+    let keyPath: WritableKeyPath<Object, Bool>
+
+    init(keyPath: WritableKeyPath<Object, Bool>) {
+        self.keyPath = keyPath
+    }
+
+    func isIncluded(_ object: Object) -> Bool {
+        return object[keyPath: keyPath]
+    }
+
+}
+
+struct PredicateFilter<Object>: Filter {
+    typealias Object = Object
+
+    let predicate: NSPredicate
+
+    init(predicate: NSPredicate) {
+        self.predicate = predicate
+    }
+
+    func isIncluded(_ object: Object) -> Bool {
+        return predicate.evaluate(with: object)
+    }
+}
+
+class KeyPathSource<T: ZMManagedObject>: NSObject, Source, ZMContextChangeTracker {
+    typealias Object = T
+
+    var onPublish: OnPublish?
+    var onUnpublish: OnUnpublish?
+    let keyPath: WritableKeyPath<T, Bool>
+
+    init(keyPath: WritableKeyPath<T, Bool>) {
+        self.keyPath = keyPath
+    }
+
+    func objectsDidChange(_ objects: Set<NSManagedObject>) {
+        let objects = objects.compactMap({ $0 as? T })
+
+        objects.forEach { object in
+            if object[keyPath: keyPath] {
+                publish(object)
+            } else {
+                unpublish(object)
+            }
+        }
+    }
+
+    func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {
+        let keypathExpression =  NSExpression(forKeyPath: keyPath)
+        let valueExpression = NSExpression(forConstantValue: true)
+        let predicate = NSComparisonPredicate(leftExpression: keypathExpression,
+                              rightExpression: valueExpression,
+                              modifier: .direct,
+                              type: .equalTo)
+
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: T.entityName())
+        fetchRequest.predicate = predicate
+
+        return fetchRequest
+    }
+
+    func addTrackedObjects(_ objects: Set<NSManagedObject>) {
+        objectsDidChange(objects)
+    }
+}
+
+class PredicateSource<Object: ZMManagedObject>: NSObject, Source, ZMContextChangeTracker {
+    typealias Object = Object
+
+    let predicate: NSPredicate
+    var onPublish: OnPublish?
+    var onUnpublish: OnPublish?
+
+    init(_ predicate: NSPredicate) {
+        self.predicate = predicate
+    }
+
+    func objectsDidChange(_ objects: Set<NSManagedObject>) {
+        let objects = objects.compactMap({ $0 as? Object })
+
+        objects.filter({ predicate.evaluate(with: $0) }).forEach { object in
+            publish(object)
+        }
+    }
+
+    func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {
+        let fetchRequest = Object.fetchRequest()
+        fetchRequest.predicate = predicate
+        return fetchRequest
+    }
+
+    func addTrackedObjects(_ objects: Set<NSManagedObject>) {
+        objectsDidChange(objects)
+    }
+
+}
+
+protocol ObjectSyncDelegate: AnyObject {
+
+    func didFinishSyncingAllObjects()
+    func didFailToSyncAllObjects()
+
+}
+
+class ObjectSync<Object, Trans: Transcoder>: NSObject, ZMRequestGenerator, ZMContextChangeTrackerSource where Trans.Object == Object {
+
+    var pending: Set<Object> = Set()
+    var downloading: Set<Object> = Set()
+    var filters: [AnyFilter<Object>] = []
+    var sources: [Any] = []
+    var transcoder: Trans
+    var context: NSManagedObjectContext
+    weak var delegate: ObjectSyncDelegate?
+
+    var contextChangeTrackers: [ZMContextChangeTracker] {
+        return sources.compactMap({ $0 as? ZMContextChangeTracker })
+    }
+
+    var isSyncing: Bool {
+        return !pending.isEmpty || !downloading.isEmpty
+    }
+
+    init(_ transcoder: Trans, context: NSManagedObjectContext) {
+        self.transcoder = transcoder
+        self.context = context
+    }
+
+    func addSource<S: Source>(_ source: S) where S.Object == Object {
+        var source = source
+        source.onPublish { [weak self] object in
+            self?.synchronize(object)
+        }
+        source.onUnpublish { [weak self] object in
+            self?.cancel(object)
+        }
+
+        sources.append(source)
+    }
+
+    func addFilter<F: Filter>(filter: F) where F.Object == Object {
+        filters.append(AnyFilter<Object>(isIncluded: filter.isIncluded))
+    }
+
+    func synchronize(_ object: Object) {
+        synchronize([object])
+    }
+
+    func synchronize<S: Sequence>(_ objects: S) where S.Element == Object {
+        let newObjects = Set(objects)
+
+        if newObjects.isEmpty && downloading.isEmpty && pending.isEmpty {
+            delegate?.didFinishSyncingAllObjects()
+        } else {
+            pending.formUnion(Set(newObjects).subtracting(downloading))
+        }
+    }
+
+    func cancel(_ object: Object) {
+        cancel([object])
+    }
+
+    func cancel<S: Sequence>(_ objects: S) where S.Element == Object {
+        pending.subtract(objects)
+    }
+
+    func nextRequest() -> ZMTransportRequest? {
+        let nextObjects = pending.filter({ (foo) -> Bool in
+            filters.reduce(true) { (result, filter) -> Bool in
+                result && filter.isIncluded(foo)
+            }
+        })
+
+        guard !nextObjects.isEmpty else { return nil }
+
+        let scheduled = Set(nextObjects.prefix(transcoder.fetchLimit))
+
+        pending.subtract(scheduled)
+        downloading.formUnion(scheduled)
+
+        let request = transcoder.requestFor(scheduled)
+
+        request?.add(ZMCompletionHandler(on: context, block: { [weak self] (response) in
+            guard let strongSelf = self else { return }
+
+            switch response.result {
+            case .permanentError, .success:
+                strongSelf.downloading.subtract(scheduled)
+                strongSelf.transcoder.handleResponse(response: response, for: scheduled)
+
+                if case .permanentError = response.result {
+                    self?.delegate?.didFailToSyncAllObjects()
+                }
+            default:
+                strongSelf.downloading.subtract(scheduled)
+                strongSelf.pending.formUnion(scheduled)
+            }
+
+//            strongSelf.managedObjectContext.enqueueDelayedSave()
+
+            if !strongSelf.isSyncing {
+                self?.delegate?.didFinishSyncingAllObjects()
+            }
+
+            strongSelf.transcoder.handleResponse(response: response, for: scheduled)
+        }))
+
+        return request
+    }
+
+}

--- a/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -478,7 +478,7 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
 
 }
 
-class ConversationByIDTranscoder: Transcoder {
+class ConversationByIDTranscoder: ObjectTranscoder {
     typealias Object = ZMConversation
 
     let context: NSManagedObjectContext
@@ -536,7 +536,7 @@ class ConversationByIDTranscoder: Transcoder {
 
 }
 
-class ConversationByQualifiedIDTranscoder: Transcoder {
+class ConversationByQualifiedIDTranscoder: ObjectTranscoder {
     public typealias Object = ZMConversation
 
     let context: NSManagedObjectContext
@@ -598,7 +598,7 @@ class ConversationByQualifiedIDTranscoder: Transcoder {
 
 }
 
-class ConversationByIDListTranscoder: Transcoder {
+class ConversationByIDListTranscoder: ObjectTranscoder {
     public typealias Object = UUID
 
     var fetchLimit: Int = 32
@@ -650,7 +650,7 @@ class ConversationByIDListTranscoder: Transcoder {
 
 }
 
-class ConversationByQualifiedIDListTranscoder: Transcoder {
+class ConversationByQualifiedIDListTranscoder: ObjectTranscoder {
     public typealias Object = QualifiedID
 
     var fetchLimit: Int = 100

--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		16972DED2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16972DEC2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift */; };
 		169BA1CB25E9507600374343 /* Payload+Decoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169BA1CA25E9507600374343 /* Payload+Decoding.swift */; };
 		169BA1CD25E95DC900374343 /* Payload+Processing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169BA1CC25E95DC900374343 /* Payload+Processing.swift */; };
+		169FF4232718891C00330C2E /* ObjectSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FF4222718891C00330C2E /* ObjectSync.swift */; };
 		16A4891A2685CECD001F9127 /* ProteusMessageSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A489192685CECC001F9127 /* ProteusMessageSync.swift */; };
 		16A48936268A0665001F9127 /* ModifiedKeyObjectSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A48935268A0665001F9127 /* ModifiedKeyObjectSync.swift */; };
 		16A4893A268A080E001F9127 /* InsertedObjectSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A48939268A080E001F9127 /* InsertedObjectSync.swift */; };
@@ -361,6 +362,7 @@
 		16972DEC2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileRequestStrategyTests.swift; sourceTree = "<group>"; };
 		169BA1CA25E9507600374343 /* Payload+Decoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Payload+Decoding.swift"; sourceTree = "<group>"; };
 		169BA1CC25E95DC900374343 /* Payload+Processing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Payload+Processing.swift"; sourceTree = "<group>"; };
+		169FF4222718891C00330C2E /* ObjectSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectSync.swift; sourceTree = "<group>"; };
 		16A4891526849258001F9127 /* PayloadProcessing+MessageSendingStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PayloadProcessing+MessageSendingStatusTests.swift"; sourceTree = "<group>"; };
 		16A489192685CECC001F9127 /* ProteusMessageSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusMessageSync.swift; sourceTree = "<group>"; };
 		16A48935268A0665001F9127 /* ModifiedKeyObjectSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifiedKeyObjectSync.swift; sourceTree = "<group>"; };
@@ -944,6 +946,7 @@
 				F1CD5D852024C281008C574E /* Protocols */,
 				F1CD5D872024C46C008C574E /* Upstream */,
 				F1CD5D882024C47D008C574E /* Downstream */,
+				169FF4222718891C00330C2E /* ObjectSync.swift */,
 			);
 			path = "Object Syncs";
 			sourceTree = "<group>";
@@ -1350,6 +1353,7 @@
 				1662ADB322B0E8B300D84071 /* VerifyLegalHoldRequestStrategy.swift in Sources */,
 				166901EC1D7081C7000FE4AF /* ZMTimedSingleRequestSync.m in Sources */,
 				F184019A2073BE0800E9F4CC /* ClientMessageRequestFactory.swift in Sources */,
+				169FF4232718891C00330C2E /* ObjectSync.swift in Sources */,
 				168D7CB226FB0E3F00789960 /* EntityActionSync.swift in Sources */,
 				168D7CBB26FB21D900789960 /* RemoveParticipantActionHandler.swift in Sources */,
 				F963E8E11D955D5500098AD3 /* SharedProtocols.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1155" title="SQCORE-1155" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10818&avatarType=issuetype" />SQCORE-1155</a>  [IOS] Refactor sync classes to be composable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This part 1 in a series of pull request which introduce the `ObjectSync`

### Issues

`IdentifierObjectSync` and several other sync classes perform very similar tasks but they are all very inflexible. And some cases they make very hard to fix some bugs like https://wearezeta.atlassian.net/browse/SQCORE-1011

### Solutions

Introduce `ObjectSync` as a composable variant of `IdentifierObjectSync` which can have different objects  sources, filters and transcoder configured. This will allow it to replace many of the existing sync objects.

In this PR we integrate the `ObjectSync` into the `ConversationRequestStrategy`.

### Testing

No behaviour is changed so regular regression run should pass.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
