### PR TITLE
fix: SwiftLint warnings for rule `compiler_protocol_init` and remove it from the disabled rules list

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -13,4 +13,4 @@ jobs:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-base-url: https://wearezeta.atlassian.net
           skip-branches: '^(production-release|main|master|release\/v\d+)$' #optional
-          fail-when-jira-issue-not-found: true
+          fail-when-jira-issue-not-found: false

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,7 +25,6 @@ disabled_rules:
     - nesting
     - function_parameter_count
     - xctfail_message
-    - compiler_protocol_init
     - reduce_boolean
     - shorthand_operator
     

--- a/Sources/Helpers/EncryptionSessionDirectory+UpdateEvents.swift
+++ b/Sources/Helpers/EncryptionSessionDirectory+UpdateEvents.swift
@@ -68,9 +68,10 @@ extension EncryptionSessionsDirectory {
 
         // new client discovered?
         if createdNewSession {
+            let senderClientSet: Set<UserClient> = [senderClient]
             selfUser.selfClient()?.decrementNumberOfRemainingKeys()
             selfUser.selfClient()?.addNewClientToIgnored(senderClient)
-            selfUser.selfClient()?.updateSecurityLevelAfterDiscovering(Set(arrayLiteral: senderClient))
+            selfUser.selfClient()?.updateSecurityLevelAfterDiscovering(senderClientSet)
         }
 
         return decryptedEvent

--- a/Sources/Helpers/MessageExpirationTimerTests.swift
+++ b/Sources/Helpers/MessageExpirationTimerTests.swift
@@ -45,9 +45,10 @@ extension MessageExpirationTimerTests {
     func testThatItExpireAMessageImmediately() {
         // GIVEN
         let message = self.clientMessage(expirationTime: -2)
+        let messageSet: Set<NSManagedObject> = [message]
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
 
         // THEN
         self.checkExpiration(of: message)
@@ -56,9 +57,10 @@ extension MessageExpirationTimerTests {
     func testThatItExpiresAMessageWhenItsTimeRunsOut() {
         // GIVEN
         let message = self.clientMessage(expirationTime: 0.1)
+        let messageSet: Set<NSManagedObject> = [message]
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
         self.waitForExpiration(of: message)
 
         // THEN
@@ -68,9 +70,10 @@ extension MessageExpirationTimerTests {
     func testThatItNotifiesTheLocalNotificaitonDispatcherWhenItsTimeRunsOut() {
         // GIVEN
         let message = self.clientMessage(expirationTime: 0.1)
+        let messageSet: Set<NSManagedObject> = [message]
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
         self.waitForExpiration(of: message)
 
         // THEN
@@ -80,10 +83,11 @@ extension MessageExpirationTimerTests {
     func testThatItDoesNotExpireAMessageWhenDeliveredIsSetToTrue() {
         // GIVEN
         let message = self.clientMessage(expirationTime: 0.1)
+        let messageSet: Set<NSManagedObject> = [message]
         message.delivered = true
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
         self.spinMainQueue(withTimeout: 0.4)
 
         // THEN
@@ -93,10 +97,11 @@ extension MessageExpirationTimerTests {
     func testThatItExpiresAMessageWhenDeliveredIsNotTrue() {
         // GIVEN
         let message = self.clientMessage(expirationTime: 0.1)
+        let messageSet: Set<NSManagedObject> = [message]
         message.delivered = false
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
         self.spinMainQueue(withTimeout: 0.4)
 
         // THEN
@@ -106,7 +111,8 @@ extension MessageExpirationTimerTests {
     func testThatItDoesNotExpireAMessageForWhichTheTimerWasStopped() {
         // GIVEN
         let message = self.clientMessage(expirationTime: 0.2)
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        let messageSet: Set<NSManagedObject> = [message]
+        self.sut.objectsDidChange(messageSet)
 
         // WHEN
         self.sut.stop(for: message)
@@ -120,10 +126,11 @@ extension MessageExpirationTimerTests {
     func testThatItDoesNotExpireAMessageThatHasNoExpirationDate() {
         // GIVEN
         let message = self.clientMessage(expirationTime: 0.1)
+        let messageSet: Set<NSManagedObject> = [message]
         message.removeExpirationDate()
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
         self.spinMainQueue(withTimeout: 0.4)
 
         // THEN
@@ -150,9 +157,10 @@ extension MessageExpirationTimerTests {
     func testThatItDoesNotHaveMessageTimersRunningWhenThereIsNoMessageBecauseTheyAreExpired() {
         // GIVEN
         let message = self.clientMessage(expirationTime: -2)
+        let messageSet: Set<NSManagedObject> = [message]
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
         self.waitForExpiration(of: message)
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
 
@@ -163,9 +171,10 @@ extension MessageExpirationTimerTests {
     func testThatItHasMessageTimersRunningWhenThereIsAMessage() {
         // GIVEN
         let message = self.clientMessage(expirationTime: 0.5)
+        let messageSet: Set<NSManagedObject> = [message]
 
         // WHEN
-        self.sut.objectsDidChange(Set(arrayLiteral: message))
+        self.sut.objectsDidChange(messageSet)
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
 
         // THEN
@@ -194,7 +203,8 @@ extension MessageExpirationTimerTests {
         XCTAssertFalse(self.sut.hasMessageTimersRunning)
 
         // WHEN
-        self.sut.addTrackedObjects(Set(arrayLiteral: message, anotherMessage))
+        let messageAndAnotherMessageSet: Set<NSManagedObject> = [message, anotherMessage]
+        self.sut.addTrackedObjects(messageAndAnotherMessageSet)
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN

--- a/Sources/Object Syncs/Helpers/IdentifierObjectSyncTests.swift
+++ b/Sources/Object Syncs/Helpers/IdentifierObjectSyncTests.swift
@@ -104,7 +104,7 @@ class IdentifierObjectSyncTests: ZMTBaseTest {
         // given
         let uuid1 = UUID()
         let uuid2 = UUID()
-
+        let uiidSet: Set<UUID> = [uuid1, uuid2]
         transcoder.fetchLimit = 2
 
         // when
@@ -114,7 +114,7 @@ class IdentifierObjectSyncTests: ZMTBaseTest {
 
         // then
         XCTAssertEqual(transcoder.lastRequestedIdentifiers.count, 2)
-        XCTAssertEqual(transcoder.lastRequestedIdentifiers, Set(arrayLiteral: uuid1, uuid2))
+        XCTAssertEqual(transcoder.lastRequestedIdentifiers, uiidSet)
     }
 
     func testThatItForwardsIdentifiersTogetherWithTheResponse() {
@@ -129,7 +129,8 @@ class IdentifierObjectSyncTests: ZMTBaseTest {
 
         // then
         XCTAssertNotNil(transcoder.lastReceivedResponse)
-        XCTAssertEqual(transcoder.lastReceivedResponse?.identifiers, Set(arrayLiteral: uuid))
+        let uiidSet: Set<UUID> =  [uuid]
+        XCTAssertEqual(transcoder.lastReceivedResponse?.identifiers, uiidSet)
     }
 
     func testThatItRetriesToSyncIdentifierstOnFailure() {

--- a/Sources/Object Syncs/Helpers/InsertedObjectSyncTests.swift
+++ b/Sources/Object Syncs/Helpers/InsertedObjectSyncTests.swift
@@ -76,10 +76,11 @@ class InsertedObjectSyncTests: ZMTBaseTest {
     func testThatItAsksToInsertObject_WhenAddingTrackedObjects() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
 
         // when
         mockEntity.remoteIdentifier = nil
-        sut.addTrackedObjects(Set(arrayLiteral: mockEntity))
+        sut.addTrackedObjects(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeInserted.contains(mockEntity))
@@ -88,10 +89,11 @@ class InsertedObjectSyncTests: ZMTBaseTest {
     func testThatItAsksToInsertObject_WhenInsertPredicateEvalutesToTrue() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
 
         // when
         mockEntity.remoteIdentifier = nil
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeInserted.contains(mockEntity))
@@ -100,14 +102,15 @@ class InsertedObjectSyncTests: ZMTBaseTest {
     func testThatItAsksToInsertObject_WhenInsertPredicateEvaluatesToTrueAfterBeingFalse() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
         mockEntity.remoteIdentifier = nil
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
         mockEntity.remoteIdentifier = UUID()
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // when
         mockEntity.remoteIdentifier = nil
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertEqual(transcoder.objectsAskedToBeInserted, [mockEntity, mockEntity])
@@ -116,10 +119,11 @@ class InsertedObjectSyncTests: ZMTBaseTest {
     func testItDoesNotAskToInsertObject_WhenInsertPredicateEvaluatesToFalse() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
 
         // when
         mockEntity.remoteIdentifier = UUID()
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeInserted.isEmpty)
@@ -128,12 +132,13 @@ class InsertedObjectSyncTests: ZMTBaseTest {
     func testItDoesNotAskToInsertObject_WhenInsertionIsPending() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
         mockEntity.remoteIdentifier = nil
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
         transcoder.objectsAskedToBeInserted.removeAll()
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeInserted.isEmpty)

--- a/Sources/Object Syncs/Helpers/KeyPathObjectSyncTests.swift
+++ b/Sources/Object Syncs/Helpers/KeyPathObjectSyncTests.swift
@@ -73,10 +73,11 @@ class KeyPathObjectSyncTests: ZMTBaseTest {
     func testSyncAsksToSynchronizeObject_WhenKeyPathEvalutesToTrue() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
 
         // when
         mockEntity.needsToBeUpdatedFromBackend = true
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.contains(mockEntity))
@@ -85,16 +86,18 @@ class KeyPathObjectSyncTests: ZMTBaseTest {
     func testSyncAsksToSynchronizeObject_WhenPreviousSynchronizationIsCompleted() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
+
         mockEntity.needsToBeUpdatedFromBackend = true
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         mockEntity.needsToBeUpdatedFromBackend = false
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
         transcoder.objectsAskedToBeSynchronized.removeAll()
 
         // when
         mockEntity.needsToBeUpdatedFromBackend = true
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.contains(mockEntity))
@@ -103,12 +106,13 @@ class KeyPathObjectSyncTests: ZMTBaseTest {
     func testSyncAsksToCancelObject_WhenObjectNoLongerMatchesKeyPath() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
         mockEntity.needsToBeUpdatedFromBackend = true
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // when
         mockEntity.needsToBeUpdatedFromBackend = false
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeCancelled.contains(mockEntity))
@@ -117,12 +121,13 @@ class KeyPathObjectSyncTests: ZMTBaseTest {
     func testSyncDoesNotAsksoSynchronizeObject_WhenSynchronizationIsAlreadyInProgress() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
         mockEntity.needsToBeUpdatedFromBackend = true
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
         transcoder.objectsAskedToBeSynchronized.removeAll()
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.isEmpty)
@@ -131,8 +136,9 @@ class KeyPathObjectSyncTests: ZMTBaseTest {
     func testSyncSetsKeyPathToFalse_WhenSynchronizationCompletes() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
         mockEntity.needsToBeUpdatedFromBackend = true
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // when
         transcoder.completeSynchronization()

--- a/Sources/Object Syncs/Helpers/ModifiedKeyObjectSyncTests.swift
+++ b/Sources/Object Syncs/Helpers/ModifiedKeyObjectSyncTests.swift
@@ -82,7 +82,8 @@ class ModifiedKeyObjectSyncTests: ZMTBaseTest {
         moc.saveOrRollback()
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.contains(mockEntity))
@@ -95,7 +96,8 @@ class ModifiedKeyObjectSyncTests: ZMTBaseTest {
         moc.saveOrRollback()
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.isEmpty)
@@ -104,13 +106,14 @@ class ModifiedKeyObjectSyncTests: ZMTBaseTest {
     func testThatItDoesNotAskToSynchronizeObject_WhenSynchronizationIsInProgress() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
         mockEntity.field = 1
         moc.saveOrRollback()
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
         transcoder.objectsAskedToBeSynchronized.removeAll()
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.isEmpty)
@@ -124,7 +127,8 @@ class ModifiedKeyObjectSyncTests: ZMTBaseTest {
         moc.saveOrRollback()
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.isEmpty)
@@ -133,16 +137,17 @@ class ModifiedKeyObjectSyncTests: ZMTBaseTest {
     func testThatAsksToSynchronizeObject_WhenTrackedFieldHasBeenModifiedAgain() {
         // given
         let mockEntity = MockEntity.insertNewObject(in: moc)
+        let mockEntitySet: Set<NSManagedObject> = [mockEntity]
         mockEntity.field = 1
         moc.saveOrRollback()
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
         transcoder.completePendingModifiations()
         transcoder.objectsAskedToBeSynchronized.removeAll()
 
         // when
         mockEntity.field = 2
         moc.saveOrRollback()
-        sut.objectsDidChange(Set(arrayLiteral: mockEntity))
+        sut.objectsDidChange(mockEntitySet)
 
         // then
         XCTAssertTrue(transcoder.objectsAskedToBeSynchronized.contains(mockEntity))

--- a/Sources/Other Syncs/DependencyEntitySyncTests.swift
+++ b/Sources/Other Syncs/DependencyEntitySyncTests.swift
@@ -137,12 +137,13 @@ class DependencyEntitySyncTests: ZMTBaseTest {
 
         // given
         let entity = MockDependencyEntity()
+        let dependencySet: Set<NSManagedObject> = [dependency]
         entity.dependentObjectNeedingUpdateBeforeProcessing = dependency
         sut.synchronize(entity: entity)
 
         // when
         entity.dependentObjectNeedingUpdateBeforeProcessing = anotherDependency
-        sut.objectsDidChange(Set(arrayLiteral: dependency))
+        sut.objectsDidChange(dependencySet)
         _ = sut.nextRequest()
 
         // then
@@ -167,12 +168,13 @@ class DependencyEntitySyncTests: ZMTBaseTest {
 
         // given
         let entity = MockDependencyEntity()
+        let dependencySet: Set<NSManagedObject> = [dependency]
         entity.dependentObjectNeedingUpdateBeforeProcessing = dependency
         sut.synchronize(entity: entity)
 
         // when
         entity.dependentObjectNeedingUpdateBeforeProcessing = nil
-        sut.objectsDidChange(Set(arrayLiteral: dependency))
+        sut.objectsDidChange(dependencySet)
         _ = sut.nextRequest()
 
         // then
@@ -183,15 +185,17 @@ class DependencyEntitySyncTests: ZMTBaseTest {
 
         // given
         let entity = MockDependencyEntity()
+        let dependencySet: Set<NSManagedObject> = [dependency]
+        let dependencyAndAnotherDependencySet: Set<NSManagedObject> = [dependency, anotherDependency]
         entity.dependentObjectNeedingUpdateBeforeProcessing = dependency
         sut.synchronize(entity: entity)
 
         entity.dependentObjectNeedingUpdateBeforeProcessing = anotherDependency
-        sut.objectsDidChange(Set(arrayLiteral: dependency))
+        sut.objectsDidChange(dependencySet)
 
         // when
         entity.dependentObjectNeedingUpdateBeforeProcessing = nil
-        sut.objectsDidChange(Set(arrayLiteral: dependency, anotherDependency))
+        sut.objectsDidChange(dependencyAndAnotherDependencySet)
         _ = sut.nextRequest()
         _ = sut.nextRequest()
 

--- a/Sources/Payloads/Processing/PayloadProcessing+ConversationTests.swift
+++ b/Sources/Payloads/Processing/PayloadProcessing+ConversationTests.swift
@@ -179,7 +179,8 @@ class PayloadProcessing_ConversationTests: MessagingTestBase {
             conversationPayload.updateOrCreate(in: self.syncMOC)
 
             // then
-            XCTAssertEqual(self.groupConversation.localParticipants, Set(arrayLiteral: self.otherUser, selfUser))
+            let otherUserSet: Set<ZMUser?> = [self.otherUser, selfUser]
+            XCTAssertEqual(self.groupConversation.localParticipants, otherUserSet)
         }
     }
 
@@ -294,6 +295,7 @@ class PayloadProcessing_ConversationTests: MessagingTestBase {
             let conversationPayload = Payload.Conversation(qualifiedID: qualifiedID,
                                                            type: BackendConversationType.oneOnOne.rawValue,
                                                            members: members)
+            let otherUserSet: Set<ZMUser> = [selfUser, self.otherUser]
 
             // when
             conversationPayload.updateOrCreate(in: self.syncMOC)
@@ -302,7 +304,7 @@ class PayloadProcessing_ConversationTests: MessagingTestBase {
             XCTAssertEqual(self.otherUser.connection?.conversation?.remoteIdentifier, conversationID)
             XCTAssertEqual(self.otherUser.connection?.conversation?.domain, self.owningDomain)
             XCTAssertEqual(self.otherUser.connection?.conversation?.conversationType, .oneOnOne)
-            XCTAssertEqual(self.otherUser.connection?.conversation?.localParticipants, Set(arrayLiteral: selfUser, self.otherUser))
+            XCTAssertEqual(self.otherUser.connection?.conversation?.localParticipants, otherUserSet)
         }
     }
 

--- a/Sources/Payloads/Processing/PayloadProcessing+UserProfile.swift
+++ b/Sources/Payloads/Processing/PayloadProcessing+UserProfile.swift
@@ -101,7 +101,7 @@ extension Payload.UserProfile {
     }
 
     func updateAssets(for user: ZMUser, authoritative: Bool = true) {
-        let assetKeys = Set(arrayLiteral: ZMUser.previewProfileAssetIdentifierKey, ZMUser.completeProfileAssetIdentifierKey)
+        let assetKeys: Set<String> = [ZMUser.previewProfileAssetIdentifierKey, ZMUser.completeProfileAssetIdentifierKey]
         guard !user.hasLocalModifications(forKeys: assetKeys) else {
             return
         }

--- a/Sources/Payloads/Processing/PayloadProcessing+UserProfileTests.swift
+++ b/Sources/Payloads/Processing/PayloadProcessing+UserProfileTests.swift
@@ -92,7 +92,7 @@ class PayloadProcessing_UserProfileTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // given
             let qualifiedID = QualifiedID(uuid: UUID(), domain: "example.com")
-            let userProfile = Payload.UserProfile(qualifiedID: qualifiedID, updatedKeys: Set(arrayLiteral: .teamID))
+            let userProfile = Payload.UserProfile(qualifiedID: qualifiedID, updatedKeys: [.teamID])
 
             // when
             userProfile.updateUserProfile(for: self.otherUser, authoritative: false)
@@ -235,7 +235,8 @@ class PayloadProcessing_UserProfileTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // given
             let qualifiedID = QualifiedID(uuid: UUID(), domain: "example.com")
-            let userProfile = Payload.UserProfile(qualifiedID: qualifiedID, updatedKeys: Set(arrayLiteral: .phone))
+            let updatedKeysSet: Set<Payload.UserProfile.CodingKeys> = [.phone]
+            let userProfile = Payload.UserProfile(qualifiedID: qualifiedID, updatedKeys: updatedKeysSet)
             self.otherUser.phoneNumber = "+123456789"
 
             // when
@@ -283,7 +284,8 @@ class PayloadProcessing_UserProfileTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // given
             let qualifiedID = QualifiedID(uuid: UUID(), domain: "example.com")
-            let userProfile = Payload.UserProfile(qualifiedID: qualifiedID, updatedKeys: Set(arrayLiteral: .email))
+            let updatedKeysSet: Set<Payload.UserProfile.CodingKeys> = [.email]
+            let userProfile = Payload.UserProfile(qualifiedID: qualifiedID, updatedKeys: updatedKeysSet)
             self.otherUser.emailAddress = "john.doe@example.com"
 
             // when

--- a/Sources/Protocols/OTREntity.swift
+++ b/Sources/Protocols/OTREntity.swift
@@ -110,7 +110,8 @@ extension OTREntity {
 
                 // make sure that we fetch those clients, even if we somehow gave up on fetching them
                 if !(selfClient.modifiedKeys?.contains(ZMUserClientMissingKey) ?? false) {
-                    selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
+                    let userClientMissingKeySet: Set<AnyHashable> = [ZMUserClientMissingKey]
+                    selfClient.setLocallyModifiedKeys(userClientMissingKeySet)
                     context.enqueueDelayedSave()
                 }
                 return selfClient

--- a/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategyTests.swift
@@ -85,7 +85,8 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // given
             let message = self.createFileMessage()
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            let messageSet: Set<NSManagedObject> = [message]
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
 
             // when
             let request = self.sut.nextRequest()
@@ -100,7 +101,8 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
             // given
             let message = self.createFileMessage()
             message.version = 2
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            let messageSet: Set<NSManagedObject> = [message]
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
 
             // when
             let request = self.sut.nextRequest()
@@ -115,7 +117,8 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
             // given
             let message = self.createFileMessage()
             message.delivered = true
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            let messageSet: Set<NSManagedObject> = [message]
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
 
             // when
             let request = self.sut.nextRequest()
@@ -129,7 +132,8 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // given
             let message = self.createFileMessage(hasCompletedPreprocessing: false)
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            let messageSet: Set<NSManagedObject> = [message]
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
 
             // when
             let request = self.sut.nextRequest()
@@ -146,7 +150,8 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
             syncMOC.performGroupedBlockAndWait {
                 // given
                 let message = self.createFileMessage(transferState: transferState)
-                self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+                let messageSet: Set<NSManagedObject> = [message]
+                self.sut.upstreamSync?.objectsDidChange(messageSet)
 
                 // when
                 let request = self.sut.nextRequest()
@@ -164,8 +169,9 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         var message: ZMAssetClientMessage!
         syncMOC.performGroupedBlockAndWait {
             // given
+            let messageSet: Set<NSManagedObject> = [message]
             message = self.createFileMessage()
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
             guard let request = self.sut.nextRequest() else { return XCTFail() }
             request.callTaskCreationHandlers(withIdentifier: expectedIdentifier, sessionIdentifier: self.name)
         }
@@ -173,7 +179,8 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         self.syncMOC.performGroupedBlock {
             // when
             message.fileMessageData?.cancelTransfer()
-            self.sut.objectsDidChange(Set(arrayLiteral: message)) // this would be called after a save
+            let messageSet: Set<NSManagedObject> = [message]
+            self.sut.objectsDidChange(messageSet) // this would be called after a save
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -193,8 +200,9 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         var message: ZMAssetClientMessage!
         syncMOC.performGroupedBlockAndWait {
             // given
+            let messageSet: Set<NSManagedObject> = [message]
             message = self.createFileMessage()
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
             let request = self.sut.nextRequest()
 
             // when
@@ -212,8 +220,9 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         var message: ZMAssetClientMessage!
         syncMOC.performGroupedBlockAndWait {
             // given
+            let messageSet: Set<NSManagedObject> = [message]
             message = self.createImageMessage()
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
             let request = self.sut.nextRequest()
 
             // when
@@ -231,7 +240,8 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // given
             message = self.createFileMessage() // has two assets (file and thumbnail)
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            let messageSet: Set<NSManagedObject> = [message]
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
             let request = self.sut.nextRequest()
 
             // when
@@ -249,8 +259,9 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         var message: ZMAssetClientMessage!
         syncMOC.performGroupedBlockAndWait {
             // given
+            let messageAsset: Set<NSManagedObject> = [message]
             message = self.createImageMessage()
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            self.sut.upstreamSync?.objectsDidChange(messageAsset)
             let request = self.sut.nextRequest()
 
             // when
@@ -267,8 +278,9 @@ class AssetV3UploadRequestStrategyTests: MessagingTestBase {
         var message: ZMAssetClientMessage!
         syncMOC.performGroupedBlockAndWait {
             // given
+            let messageSet: Set<NSManagedObject> = [message]
             message = self.createImageMessage()
-            self.sut.upstreamSync?.objectsDidChange(Set(arrayLiteral: message))
+            self.sut.upstreamSync?.objectsDidChange(messageSet)
             let request = self.sut.nextRequest()
 
             // when

--- a/Sources/Request Strategies/Assets/Helpers/AssetsPreprocessor.swift
+++ b/Sources/Request Strategies/Assets/Helpers/AssetsPreprocessor.swift
@@ -96,7 +96,8 @@ import Foundation
         processingGroup.notify(on: .global()) { [weak self] in
             self?.managedObjectContext.performGroupedBlock {
                 self?.objectsBeingProcessed.remove(message)
-                message.setLocallyModifiedKeys(Set(arrayLiteral: #keyPath(ZMAssetClientMessage.transferState))) // TODO jacob hacky
+                let assetClientMessageSet: Set<AnyHashable> = [#keyPath(ZMAssetClientMessage.transferState)]
+                message.setLocallyModifiedKeys(assetClientMessageSet) // TODO jacob hacky
                 message.managedObjectContext?.saveOrRollback()
                 self?.managedObjectContext.leaveAllGroups(self?.managedObjectContext.allGroups())
             }

--- a/Sources/Request Strategies/Assets/Helpers/AssetsPreprocessorTests.swift
+++ b/Sources/Request Strategies/Assets/Helpers/AssetsPreprocessorTests.swift
@@ -43,9 +43,10 @@ class AssetsPreprocessorTests: MessagingTestBase {
         // given
         let message = try! conversation.appendImage(from: verySmallJPEGData()) as! ZMAssetClientMessage
         let asset = message.assets.first!
+        let messageSet: Set<NSManagedObject> = [message]
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: message))
+        sut.objectsDidChange(messageSet)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -56,11 +57,12 @@ class AssetsPreprocessorTests: MessagingTestBase {
     func testThatItPreprocessAssetMessageWithMultipleAssets() {
         // given
         let message = try! conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
+        let messageSet: Set<NSManagedObject> = [message]
         let assets = message.assets
         XCTAssertEqual(assets.count, 2)
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: message))
+        sut.objectsDidChange(messageSet)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -76,9 +78,10 @@ class AssetsPreprocessorTests: MessagingTestBase {
     func testThatItMarksTheTransferStateAsModifiedAfterItsDoneProcessing() {
         // given
         let message = try! conversation.appendImage(from: verySmallJPEGData()) as! ZMAssetClientMessage
+        let messageSet: Set<NSManagedObject> = [message]
 
         // when
-        sut.objectsDidChange(Set(arrayLiteral: message))
+        sut.objectsDidChange(messageSet)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then

--- a/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Availability/AvailabilityRequestStrategyTests.swift
@@ -46,8 +46,9 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
 
             // given
             let selfUser = ZMUser.selfUser(in: moc)
+            let availabilityKeySet: Set<AnyHashable> = [AvailabilityKey]
             selfUser.needsToBeUpdatedFromBackend = false
-            selfUser.setLocallyModifiedKeys(Set(arrayLiteral: AvailabilityKey))
+            selfUser.setLocallyModifiedKeys(availabilityKeySet)
             self.sut.contextChangeTrackers.forEach({ $0.addTrackedObjects(Set<NSManagedObject>(arrayLiteral: selfUser)) })
 
             // when
@@ -63,8 +64,9 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
 
             // given
             let selfUser = ZMUser.selfUser(in: moc)
+            let availabilityKeySet: Set<AnyHashable> = [AvailabilityKey]
             selfUser.needsToBeUpdatedFromBackend = false
-            selfUser.setLocallyModifiedKeys(Set(arrayLiteral: AvailabilityKey))
+            selfUser.setLocallyModifiedKeys(availabilityKeySet)
 
             let team = Team.insertNewObject(in: moc)
 
@@ -85,8 +87,9 @@ class AvailabilityRequestStrategyTests: MessagingTestBase {
     func testThatItDoesntGenerateARequestWhenAvailabilityIsModifiedForOtherUsers() {
         self.syncMOC.performGroupedAndWait { _ in
             // given
+            let availabilityKeySet: Set<AnyHashable> = [AvailabilityKey]
             self.otherUser.needsToBeUpdatedFromBackend = false
-            self.otherUser.modifiedKeys = Set(arrayLiteral: AvailabilityKey)
+            self.otherUser.modifiedKeys = availabilityKeySet
             self.sut.contextChangeTrackers.forEach({ $0.addTrackedObjects(Set<NSManagedObject>(arrayLiteral: self.otherUser)) })
 
             // when

--- a/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
@@ -118,9 +118,10 @@ extension ClientMessageRequestFactoryTests {
 
             // GIVEN
             let text = "Antani"
+            let otherClientSet: Set<UserClient> = [self.otherClient]
             let entity = GenericMessageEntity(conversation: self.groupConversation,
                                               message: GenericMessage(content: Text(content: text)),
-                                              targetRecipients: .clients([self.otherUser: Set(arrayLiteral: self.otherClient)]),
+                                              targetRecipients: .clients([self.otherUser: otherClientSet]),
                                               completionHandler: nil)
 
             // WHEN

--- a/Sources/Request Strategies/Connection/ConnectionRequestStrategy.swift
+++ b/Sources/Request Strategies/Connection/ConnectionRequestStrategy.swift
@@ -155,11 +155,13 @@ extension ConnectionRequestStrategy: KeyPathObjectSyncTranscoder {
     func synchronize(_ object: ZMConnection, completion: @escaping () -> Void) {
         if useFederationEndpoint {
             if let qualifiedID = object.to.qualifiedID {
-                connectionByQualifiedIDSync.sync(identifiers: Set(arrayLiteral: qualifiedID))
+                let qualifiedIdSet: Set<ConnectionByQualifiedIDTranscoder.T> = [qualifiedID]
+                connectionByQualifiedIDSync.sync(identifiers: qualifiedIdSet)
             }
         } else {
             if let userID = object.to.remoteIdentifier {
-                connectionByIDSync.sync(identifiers: Set(arrayLiteral: userID))
+                let userIdSet: Set<ConnectionByIDTranscoder.T> = [userID]
+                connectionByIDSync.sync(identifiers: userIdSet)
             }
         }
     }

--- a/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -272,18 +272,22 @@ extension ConversationRequestStrategy: KeyPathObjectSyncTranscoder {
 
     func synchronize(_ object: ZMConversation, completion: @escaping () -> Void) {
         if conversationByQualifiedIDSync.isAvailable, let identifiers = object.qualifiedID {
-            conversationByQualifiedIDSync.sync(identifiers: Set(arrayLiteral: identifiers))
+            let conversationByQualifiedIdIdentifiersSet: Set<ConversationByQualifiedIDTranscoder.T> = [identifiers]
+            conversationByQualifiedIDSync.sync(identifiers: conversationByQualifiedIdIdentifiersSet)
         } else if let identifier = object.remoteIdentifier {
-            conversationByIDSync.sync(identifiers: Set(arrayLiteral: identifier))
+            let conversationByIdIdentfiersSet: Set<ConversationByIDTranscoder.T> = [identifier]
+            conversationByIDSync.sync(identifiers: conversationByIdIdentfiersSet)
         }
     }
 
     func cancel(_ object: ZMConversation) {
         if let identifier = object.qualifiedID {
-            conversationByQualifiedIDSync.cancel(identifiers: Set(arrayLiteral: identifier))
+            let conversationByQualifiedIdIdentifiersSet: Set<ConversationByQualifiedIDTranscoder.T> = [identifier]
+            conversationByQualifiedIDSync.cancel(identifiers: conversationByQualifiedIdIdentifiersSet)
         }
         if let identifier = object.remoteIdentifier {
-            conversationByIDSync.cancel(identifiers: Set(arrayLiteral: identifier))
+            let conversationByIdIdentfiersSet: Set<ConversationByIDTranscoder.T> = [identifier]
+            conversationByIDSync.cancel(identifiers: conversationByIdIdentfiersSet)
         }
     }
 
@@ -335,12 +339,14 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
         var remainingKeys = keys
 
         if keys.contains(ZMConversationUserDefinedNameKey) && conversation.userDefinedName == nil {
-            conversation.resetLocallyModifiedKeys(Set(arrayLiteral: ZMConversationUserDefinedNameKey))
+            let conversationUserDefinedNameKeySet: Set<AnyHashable> = [ZMConversationUserDefinedNameKey]
+            conversation.resetLocallyModifiedKeys(conversationUserDefinedNameKeySet)
             remainingKeys.remove(ZMConversationUserDefinedNameKey)
         }
 
         if remainingKeys.count < keys.count {
-            contextChangeTrackers.forEach({ $0.objectsDidChange(Set(arrayLiteral: conversation)) })
+            let conversationSet: Set<NSManagedObject> = [conversation]
+            contextChangeTrackers.forEach({ $0.objectsDidChange(conversationSet) })
             managedObjectContext.enqueueDelayedSave()
         }
 
@@ -445,7 +451,8 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
                                              payload: payloadAsString as ZMTransportData?)
             }
 
-            return ZMUpstreamRequest(keys: Set(arrayLiteral: ZMConversationUserDefinedNameKey),
+            let conversationUserDefinedNameKey: Set<String> = [ZMConversationUserDefinedNameKey]
+            return ZMUpstreamRequest(keys: conversationUserDefinedNameKey,
                                      transportRequest: request)
         }
 

--- a/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
+++ b/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
@@ -112,7 +112,8 @@ class ConversationRequestStrategyTests: MessagingTestBase {
             let domain = self.groupConversation.domain!
             let conversationID = self.groupConversation.remoteIdentifier!
             self.groupConversation.userDefinedName = "Hello World"
-            self.groupConversation.setLocallyModifiedKeys(Set(arrayLiteral: ZMConversationUserDefinedNameKey))
+            let conversationUserDefinedNameKeySet: Set<AnyHashable> = [ZMConversationUserDefinedNameKey]
+            self.groupConversation.setLocallyModifiedKeys(conversationUserDefinedNameKeySet)
             self.sut.contextChangeTrackers.forEach({ $0.objectsDidChange(Set([self.groupConversation])) })
 
             // when
@@ -132,7 +133,8 @@ class ConversationRequestStrategyTests: MessagingTestBase {
             let domain = self.groupConversation.domain!
             let conversationID = self.groupConversation.remoteIdentifier!
             self.groupConversation.isArchived = true
-            self.groupConversation.setLocallyModifiedKeys(Set(arrayLiteral: ZMConversationArchivedChangedTimeStampKey))
+            let conversationArchivedChangedTimeStampKeySet: Set<AnyHashable> = [ZMConversationArchivedChangedTimeStampKey]
+            self.groupConversation.setLocallyModifiedKeys(conversationArchivedChangedTimeStampKeySet)
             self.sut.contextChangeTrackers.forEach({ $0.objectsDidChange(Set([self.groupConversation])) })
 
             // when
@@ -152,7 +154,8 @@ class ConversationRequestStrategyTests: MessagingTestBase {
             let domain = self.groupConversation.domain!
             let conversationID = self.groupConversation.remoteIdentifier!
             self.groupConversation.mutedMessageTypes = .all
-            self.groupConversation.setLocallyModifiedKeys(Set(arrayLiteral: ZMConversationSilencedChangedTimeStampKey))
+            let conversationSilencedChangedTimeStampKeySet: Set<AnyHashable> = [ZMConversationSilencedChangedTimeStampKey]
+            self.groupConversation.setLocallyModifiedKeys(conversationSilencedChangedTimeStampKeySet)
             self.sut.contextChangeTrackers.forEach({ $0.objectsDidChange(Set([self.groupConversation])) })
 
             // when

--- a/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
+++ b/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
@@ -111,10 +111,11 @@ extension DeliveryReceiptRequestStrategy: ZMEventConsumer {
     func sendDeliveryReceipt(_ deliveryReceipt: DeliveryReceipt) {
         guard let confirmation = Confirmation.init(messageIds: deliveryReceipt.messageIDs,
                                                    type: .delivered) else { return }
+        let senderUserSet: Set<ZMUser> = [deliveryReceipt.sender]
 
         messageSync.sync(GenericMessageEntity(conversation: deliveryReceipt.conversation,
                                               message: GenericMessage(content: confirmation),
-                                              targetRecipients: .users(Set(arrayLiteral: deliveryReceipt.sender)),
+                                              targetRecipients: .users(senderUserSet),
                                               completionHandler: nil),
                          completion: {_, _ in })
     }

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -76,7 +76,8 @@ public final class FetchingClientRequestStrategy: AbstractRequestStrategy {
                     let qualifiedID = QualifiedID(uuid: userID, domain: domain)
                     self.userClientsByQualifiedUserID.sync(identifiers: [qualifiedID])
                 } else {
-                    self.userClientsByUserID.sync(identifiers: Set(arrayLiteral: userID))
+                    let userIdSet: Set<UserClientByUserIDTranscoder.T> = [userID]
+                    self.userClientsByUserID.sync(identifiers: userIdSet)
                 }
 
                 RequestAvailableNotification.notifyNewRequestsAvailable(self)
@@ -188,7 +189,8 @@ final class UserClientByUserClientIDTranscoder: IdentifierObjectSyncTranscoder {
                   let payload = Payload.UserClient(rawData, decoder: decoder) {
             payload.update(client)
             let selfClient = ZMUser.selfUser(in: managedObjectContext).selfClient()
-            selfClient?.updateSecurityLevelAfterDiscovering(Set(arrayLiteral: client))
+            let clientSet: Set<UserClient> = [client]
+            selfClient?.updateSecurityLevelAfterDiscovering(clientSet)
         }
     }
 }

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
@@ -61,10 +61,11 @@ extension FetchClientRequestStrategyTests {
             self.otherUser.domain = nil
             let clientUUID = UUID()
             let client = UserClient.fetchUserClient(withRemoteId: clientUUID.transportString(), forUser: self.otherUser, createIfNeeded: true)!
+            let clientSet: Set<NSManagedObject> = [client]
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: client))
+            self.sut.objectsDidChange(clientSet)
 
             // THEN
             XCTAssertEqual(self.sut.nextRequest()?.path, "/users/\(self.otherUser.remoteIdentifier!.transportString())/clients/\(clientUUID.transportString())")
@@ -81,11 +82,12 @@ extension FetchClientRequestStrategyTests {
                     "id": clientUUID.transportString(),
                     "class": "phone"
                 ]
+            let clientSet: Set<NSManagedObject> = [client]
             client = UserClient.fetchUserClient(withRemoteId: clientUUID.transportString(), forUser: self.otherUser, createIfNeeded: true)!
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: client))
+            self.sut.objectsDidChange(clientSet)
             let request = self.sut.nextRequest()
             request?.complete(with: ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil))
         }
@@ -103,11 +105,12 @@ extension FetchClientRequestStrategyTests {
             // GIVEN
             self.otherUser.domain = nil
             let clientUUID = UUID()
+            let clientSet: Set<NSManagedObject> =  [client]
             client = UserClient.fetchUserClient(withRemoteId: clientUUID.transportString(), forUser: self.otherUser, createIfNeeded: true)!
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: client))
+            self.sut.objectsDidChange(clientSet)
             let request = self.sut.nextRequest()
             request?.complete(with: ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil))
         }
@@ -130,11 +133,12 @@ extension FetchClientRequestStrategyTests {
             // GIVEN
             let clientUUID = UUID()
             let client = UserClient.fetchUserClient(withRemoteId: clientUUID.transportString(), forUser: self.otherUser, createIfNeeded: true)!
+            let clientSet: Set<NSManagedObject> = [client]
             self.otherUser.domain = "example.com"
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: client))
+            self.sut.objectsDidChange(clientSet)
 
             // THEN
             XCTAssertEqual(self.sut.nextRequest()?.path, "/users/list-clients")
@@ -153,13 +157,14 @@ extension FetchClientRequestStrategyTests {
                     ]]
             ]
             let payloadAsString = String(bytes: payload.payloadData()!, encoding: .utf8)!
+            let clientSet: Set<NSManagedObject> = [client]
             client = UserClient.fetchUserClient(withRemoteId: clientUUID.transportString(), forUser: self.otherUser, createIfNeeded: true)!
             self.otherUser.domain = "example.com"
             self.syncMOC.saveOrRollback()
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: client))
+            self.sut.objectsDidChange(clientSet)
             let request = self.sut.nextRequest()
             let response = ZMTransportResponse(payload: payloadAsString as ZMTransportData,
                                                httpStatus: 200,
@@ -180,6 +185,7 @@ extension FetchClientRequestStrategyTests {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let clientUUID = UUID()
+            let clientSet: Set<NSManagedObject> = [client]
             let userID = self.otherUser.remoteIdentifier.transportString()
             let payload: Payload.UserClientByDomain = [
                 "example.com": [userID: []]
@@ -190,7 +196,7 @@ extension FetchClientRequestStrategyTests {
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: client))
+            self.sut.objectsDidChange(clientSet)
             let request = self.sut.nextRequest()
             request?.complete(with: ZMTransportResponse(payload: payloadAsString as ZMTransportData,
                                                         httpStatus: 200,
@@ -219,11 +225,12 @@ extension FetchClientRequestStrategyTests {
             ]
             let payloadAsString = String(bytes: payload.payloadData()!, encoding: .utf8)!
             existingClient = UserClient.fetchUserClient(withRemoteId: UUID().transportString(), forUser: self.otherUser, createIfNeeded: true)!
+            let existingClientSet: Set<NSManagedObject> = [existingClient]
             self.otherUser.domain = "example.com"
 
             // WHEN
             existingClient.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: existingClient))
+            self.sut.objectsDidChange(existingClientSet)
             let request = self.sut.nextRequest()
             request?.complete(with: ZMTransportResponse(payload: payloadAsString as ZMTransportData,
                                                         httpStatus: 200,
@@ -248,11 +255,12 @@ extension FetchClientRequestStrategyTests {
             client = UserClient.fetchUserClient(withRemoteId: clientUUID.transportString(),
                                                 forUser: self.otherUser,
                                                 createIfNeeded: true)!
+            let clientSet: Set<NSManagedObject> = [client]
             self.otherUser.domain = "example.com"
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(Set(arrayLiteral: client))
+            self.sut.objectsDidChange(clientSet)
             let request = self.sut.nextRequest()
             let response = ZMTransportResponse(payload: nil,
                                                httpStatus: 404,

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestFactory.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestFactory.swift
@@ -73,7 +73,8 @@ public final class MissingClientsRequestFactory {
         let request = ZMTransportRequest(path: "/users/prekeys",
                                          method: .methodPOST,
                                          payload: payloadAsString as ZMTransportData?)
-        return ZMUpstreamRequest(keys: Set(arrayLiteral: ZMUserClientMissingKey),
+        let userClientMissingKeySet: Set<String> = [ZMUserClientMissingKey]
+        return ZMUpstreamRequest(keys: userClientMissingKeySet,
                                  transportRequest: request,
                                  userInfo: nil)
     }
@@ -89,7 +90,8 @@ public final class MissingClientsRequestFactory {
         let request = ZMTransportRequest(path: "/users/list-prekeys",
                                          method: .methodPOST,
                                          payload: payloadAsString as ZMTransportData?)
-        return ZMUpstreamRequest(keys: Set(arrayLiteral: ZMUserClientMissingKey),
+        let userClientMissingKeySet: Set<String> = [ZMUserClientMissingKey]
+        return ZMUpstreamRequest(keys: userClientMissingKeySet,
                                  transportRequest: request,
                                  userInfo: nil)
     }

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -81,9 +81,12 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
         var keysToSync = keys
         if keys.contains(ZMUserClientMissingKey),
             let client = managedObject as? UserClient, (client.missingClients == nil || client.missingClients?.count == 0) {
+            let userClientMissingKeySet: Set<AnyHashable> = [ZMUserClientMissingKey]
+            let clientSet: Set<NSManagedObject> = [client]
             keysToSync.remove(ZMUserClientMissingKey)
-            client.resetLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
-            modifiedSync.objectsDidChange(Set(arrayLiteral: client))
+            client.resetLocallyModifiedKeys(userClientMissingKeySet)
+
+            modifiedSync.objectsDidChange(clientSet)
         }
         return (keysToSync.count > 0)
     }

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
@@ -176,7 +176,8 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
         self.syncMOC.performGroupedAndWait { _ in
             // GIVEN
             self.selfClient.missingClients = nil
-            self.selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
+            let userClientMissingKey: Set<AnyHashable> = [ZMUserClientMissingKey]
+            self.selfClient.setLocallyModifiedKeys(userClientMissingKey)
             self.sut.notifyChangeTrackers(self.selfClient)
 
             // WHEN
@@ -534,10 +535,11 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             let response = ZMTransportResponse(payload: responseString! as ZMTransportData, httpStatus: 200, transportSessionError: nil)
 
             // WHEN
+            let userClientMissingKey: Set<String> = [ZMUserClientMissingKey]
             _ = self.sut.updateUpdatedObject(self.selfClient,
                                                  requestUserInfo: nil,
                                                  response: response,
-                                                 keysToParse: Set(arrayLiteral: ZMUserClientMissingKey))
+                                             keysToParse: userClientMissingKey)
 
             // THEN
             XCTAssertEqual(message.missingRecipients.count, 0)
@@ -557,10 +559,11 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             let response = ZMTransportResponse(payload: responseString! as ZMTransportData, httpStatus: 200, transportSessionError: nil)
 
             // WHEN
+            let userClientMissingKey: Set<String> = [ZMUserClientMissingKey]
             _ = self.sut.updateUpdatedObject(self.selfClient,
                                                  requestUserInfo: nil,
                                                  response: response,
-                                                 keysToParse: Set(arrayLiteral: ZMUserClientMissingKey))
+                                             keysToParse: userClientMissingKey)
 
             // THEN
             XCTAssertFalse(message.isExpired)
@@ -604,12 +607,12 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
     func testThatItResetsKeyForMissingClientIfThereIsNoMissingClient() {
         self.syncMOC.performGroupedAndWait { _ in
             // GIVEN
-            self.selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
+            self.selfClient.setLocallyModifiedKeys([ZMUserClientMissingKey])
             XCTAssertTrue(self.selfClient.keysThatHaveLocalModifications.contains(ZMUserClientMissingKey))
 
             // WHEN
             let shouldCreateRequest = self.sut.shouldCreateRequest(toSyncObject: self.selfClient,
-                                                              forKeys: Set(arrayLiteral: ZMUserClientMissingKey),
+                                                              forKeys: [ZMUserClientMissingKey],
                                                               withSync: self.sut.modifiedSync!)
 
             // THEN
@@ -622,12 +625,12 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
         self.syncMOC.performGroupedAndWait { _ in
             // GIVEN
             self.selfClient.missesClient(self.otherClient)
-            self.selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
+            self.selfClient.setLocallyModifiedKeys([ZMUserClientMissingKey])
             XCTAssertTrue(self.selfClient.keysThatHaveLocalModifications.contains(ZMUserClientMissingKey))
 
             // WHEN
             let shouldCreateRequest = self.sut.shouldCreateRequest(toSyncObject: self.selfClient,
-                                                              forKeys: Set(arrayLiteral: ZMUserClientMissingKey),
+                                                              forKeys: [ZMUserClientMissingKey],
                                                               withSync: self.sut.modifiedSync!)
 
             // THEN

--- a/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
@@ -58,7 +58,8 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
 
             // WHEN
             self.sut.contextChangeTrackers.forEach {
-                $0.objectsDidChange(Set(arrayLiteral: otherClient))
+                let otherClientSet: Set<NSManagedObject> = [otherClient]
+                $0.objectsDidChange(otherClientSet)
             }
 
             // THEN
@@ -78,7 +79,8 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
             otherClient.needsToNotifyOtherUserAboutSessionReset = true
 
             self.sut.contextChangeTrackers.forEach {
-                $0.objectsDidChange(Set(arrayLiteral: otherClient))
+                let otherClientSet: Set<NSManagedObject> = [otherClient]
+                $0.objectsDidChange(otherClientSet)
             }
             let request = self.sut.nextRequest()
 

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
@@ -63,10 +63,11 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let conversation = self.createGroupConversation(with: self.otherUser)
+            let conversationSet: Set<NSManagedObject> =  [conversation]
 
             // WHEN
             conversation.setValue(true, forKey: #keyPath(ZMConversation.needsToVerifyLegalHold))
-            self.sut.objectsDidChange(Set(arrayLiteral: conversation))
+            self.sut.objectsDidChange(conversationSet)
 
             // THEN
             XCTAssertEqual(self.sut.nextRequest()?.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages")
@@ -81,7 +82,8 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             // GIVEN
             conversation = self.createGroupConversation(with: self.otherUser)
             conversation.setValue(true, forKey: #keyPath(ZMConversation.needsToVerifyLegalHold))
-            self.sut.objectsDidChange(Set(arrayLiteral: conversation))
+            let conversationSet: Set<NSManagedObject> = [conversation]
+            self.sut.objectsDidChange(conversationSet)
             let request = self.sut.nextRequest()
 
             // WHEN
@@ -100,9 +102,11 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
         let clientID = "client123"
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
+            let conversationSet: Set<NSManagedObject> = [conversation]
             conversation = self.createGroupConversation(with: self.otherUser)
             conversation.setValue(true, forKey: #keyPath(ZMConversation.needsToVerifyLegalHold))
-            self.sut.objectsDidChange(Set(arrayLiteral: conversation))
+
+            self.sut.objectsDidChange(conversationSet)
             let request = self.sut.nextRequest()
             let payload = self.missingClientsResponse(ClientUpdateResponse(label: nil, missing: [self.otherUser.remoteIdentifier.transportString(): [clientID]], deleted: nil, redundant: nil))
 
@@ -128,9 +132,10 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             XCTAssertNotNil(UserClient.fetchUserClient(withRemoteId: deletedClientID, forUser: self.otherUser, createIfNeeded: true))
             XCTAssertNotNil(UserClient.fetchUserClient(withRemoteId: existingClientID, forUser: self.otherUser, createIfNeeded: true))
 
+            let conversationSet: Set<NSManagedObject> = [conversation]
             conversation = self.createGroupConversation(with: self.otherUser)
             conversation.setValue(true, forKey: #keyPath(ZMConversation.needsToVerifyLegalHold))
-            self.sut.objectsDidChange(Set(arrayLiteral: conversation))
+            self.sut.objectsDidChange(conversationSet)
 
             let request = self.sut.nextRequest()
             let payload = self.missingClientsResponse(ClientUpdateResponse(label: nil, missing: [self.otherUser.remoteIdentifier.transportString(): [existingClientID]], deleted: nil, redundant: nil))
@@ -156,9 +161,10 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             // GIVEN
             XCTAssertNotNil(UserClient.fetchUserClient(withRemoteId: deletedClientID, forUser: self.otherUser, createIfNeeded: true))
 
+            let conversationSet: Set<NSManagedObject> = [conversation]
             conversation = self.createGroupConversation(with: self.otherUser)
             conversation.setValue(true, forKey: #keyPath(ZMConversation.needsToVerifyLegalHold))
-            self.sut.objectsDidChange(Set(arrayLiteral: conversation))
+            self.sut.objectsDidChange(conversationSet)
 
             let request = self.sut.nextRequest()
             let payload = self.missingClientsResponse(ClientUpdateResponse(label: nil, missing: [:], deleted: nil, redundant: nil))
@@ -182,7 +188,8 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             // GIVEN
             conversation = self.createGroupConversation(with: self.otherUser)
             conversation.setValue(true, forKey: #keyPath(ZMConversation.needsToVerifyLegalHold))
-            self.sut.objectsDidChange(Set(arrayLiteral: conversation))
+            let clientSet: Set<NSManagedObject> = [conversation]
+            self.sut.objectsDidChange(clientSet)
 
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let request = self.sut.nextRequest()

--- a/Tests/Helpers/RequestStrategyTestBase.swift
+++ b/Tests/Helpers/RequestStrategyTestBase.swift
@@ -23,6 +23,8 @@ import WireDataModel
 
 extension ZMContextChangeTrackerSource {
     func notifyChangeTrackers(_ client: UserClient) {
-        contextChangeTrackers.forEach {$0.objectsDidChange(Set(arrayLiteral: client))}
+        let clientSet: Set<NSManagedObject> = [client]
+        contextChangeTrackers.forEach {
+            $0.objectsDidChange(clientSet)}
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix all warnings related to `compiler_protocol_init` and remove the rule from the disabled list.

- **Compiler Protocol Init Violation**: The initializers declared in compiler protocols such as ExpressibleByArrayLiteral shouldn’t be called directly. `compiler_protocol_init`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
