### PR TITLE
fix: SwiftLint warnings for `legacy_constructor`, `unused_closure_parameter` and `xctfail_message`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,7 +14,6 @@ disabled_rules:
     - weak_delegate
     - inclusive_language
     - class_delegate_protocol
-    - legacy_constructor
     - legacy_hashing
     - nesting
     

--- a/Sources/Request Strategies/Assets/Helpers/LinkAttachmentsPreprocessorTests.swift
+++ b/Sources/Request Strategies/Assets/Helpers/LinkAttachmentsPreprocessorTests.swift
@@ -172,7 +172,7 @@ class LinkAttachmentsPreprocessorTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let text = "@john - www.sunet.se hello"
-            let message = self.createMessage(text: text, mentions: [Mention(range: NSMakeRange(0, 20), user: self.otherUser)])
+            let message = self.createMessage(text: text, mentions: [Mention(range: NSRange(location: 0, length: 20), user: self.otherUser)])
 
             // WHEN
             self.sut.processMessage(message)

--- a/Sources/Request Strategies/Assets/Helpers/LinkPreviewPreprocessorTests.swift
+++ b/Sources/Request Strategies/Assets/Helpers/LinkPreviewPreprocessorTests.swift
@@ -191,7 +191,7 @@ extension LinkPreviewPreprocessorTests {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let text = "@john - www.sunet.se hello"
-            let message = self.createMessage(text: text, mentions: [Mention(range: NSMakeRange(0, 20), user: self.otherUser)])
+            let message = self.createMessage(text: text, mentions: [Mention(range: NSRange(location: 0, length: 20), user: self.otherUser)])
 
             // WHEN
             self.sut.processMessage(message)

--- a/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategy.swift
+++ b/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategy.swift
@@ -1,25 +1,25 @@
 //
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 import Foundation
 
 @objcMembers public final class LinkPreviewAssetDownloadRequestStrategy: AbstractRequestStrategy, FederationAware {
-    
+
     public var useFederationEndpoint: Bool {
         get {
             requestFactory.useFederationEndpoint

--- a/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
@@ -162,7 +162,7 @@ extension ClientMessageRequestFactoryTests {
             )
 
             guard let data = request?.binaryData else {
-                return XCTFail()
+                return XCTFail("data has been nil")
             }
 
             let message = try? Proteus_NewOtrMessage(serializedData: data)
@@ -195,7 +195,7 @@ extension ClientMessageRequestFactoryTests {
             )
 
             guard let data = request?.binaryData else {
-                return XCTFail()
+                return XCTFail("data has been nil")
             }
 
             let message = try? Proteus_QualifiedNewOtrMessage(serializedData: data)

--- a/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
@@ -162,7 +162,7 @@ extension ClientMessageRequestFactoryTests {
             )
 
             guard let data = request?.binaryData else {
-                return XCTFail("data has been nil")
+                return XCTFail("request has no binary data")
             }
 
             let message = try? Proteus_NewOtrMessage(serializedData: data)
@@ -195,7 +195,7 @@ extension ClientMessageRequestFactoryTests {
             )
 
             guard let data = request?.binaryData else {
-                return XCTFail("data has been nil")
+                return XCTFail("request has no binary data")
             }
 
             let message = try? Proteus_QualifiedNewOtrMessage(serializedData: data)

--- a/Sources/Request Strategies/Conversation/Actions/UpdateRoleActionHandlerTests.swift
+++ b/Sources/Request Strategies/Conversation/Actions/UpdateRoleActionHandlerTests.swift
@@ -58,7 +58,7 @@ final class UpdateRoleActionHandlerTests: MessagingTestBase {
     }
 
     func testThatItCreatesAnExpectedRequestForUpdatingRole() throws {
-        try syncMOC.performGroupedAndWait { syncMOC in
+        try syncMOC.performGroupedAndWait { _ in
             // given
             let userID = self.user.remoteIdentifier!
             let conversationID = self.conversation.remoteIdentifier!
@@ -75,7 +75,7 @@ final class UpdateRoleActionHandlerTests: MessagingTestBase {
     }
 
     func testThatItFailsCreatingRequestWhenUserIDIsMissing() {
-        syncMOC.performGroupedAndWait { syncMOC in
+        syncMOC.performGroupedAndWait { _ in
             // given
             self.user.remoteIdentifier = nil
             let action = UpdateRoleAction(user: self.user, conversation: self.conversation, role: self.role)
@@ -89,7 +89,7 @@ final class UpdateRoleActionHandlerTests: MessagingTestBase {
     }
 
     func testThatItFailesCreatingRequestWhenConversationIDIsMissing() {
-        syncMOC.performGroupedAndWait { syncMOC in
+        syncMOC.performGroupedAndWait { _ in
             // given
             self.conversation.remoteIdentifier = nil
             let action = UpdateRoleAction(user: self.user, conversation: self.conversation, role: self.role)
@@ -103,7 +103,7 @@ final class UpdateRoleActionHandlerTests: MessagingTestBase {
     }
 
     func testThatItFailesCreatingRequestWhenRoleNameIsMissing() {
-        syncMOC.performGroupedAndWait { syncMOC in
+        syncMOC.performGroupedAndWait { _ in
             // given
             self.role.name = nil
             let action = UpdateRoleAction(user: self.user, conversation: self.conversation, role: self.role)
@@ -117,7 +117,7 @@ final class UpdateRoleActionHandlerTests: MessagingTestBase {
     }
 
     func testThatTheSucceededRequestUpdatesTheDatabase() {
-        syncMOC.performGroupedAndWait { syncMOC in
+        syncMOC.performGroupedAndWait { _ in
             // given
             let action = UpdateRoleAction(user: self.user, conversation: self.conversation, role: self.role)
             let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil)
@@ -131,7 +131,7 @@ final class UpdateRoleActionHandlerTests: MessagingTestBase {
     }
 
     func testThatTheFailedRequestDoesNotUpdateTheDatabase() {
-        syncMOC.performGroupedAndWait { syncMOC in
+        syncMOC.performGroupedAndWait { _ in
             // given
             let action = UpdateRoleAction(user: self.user, conversation: self.conversation, role: self.role)
             let response = ZMTransportResponse(payload: nil, httpStatus: 400, transportSessionError: nil)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR fixes warnings related to these three SwiftLint rules:

- **Legacy Constructor Violation**: Swift constructors are preferred over legacy convenience functions. `(legacy_constructor)`
- **Unused Closure Parameter Violation**: Unused parameter "syncMOC" in a closure should be replaced with _. `(unused_closure_parameter)`
- **XCTFail Message Violation**: An XCTFail call should include a description of the assertion. `(xctfail_message)`

Last but not least I discovered some indentation and trailing issues in a file and I fixed those too. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
