### PR TITLE
fix: restore legacy call notifications SQSERVICE-1308

### DIFF
--- a/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -22,9 +22,14 @@ import UserNotifications
 /// have associated subtypes.
 ///
 public enum LocalNotificationType {
+
+    public enum CallState {
+        case incomingCall(video: Bool)
+        case missedCall
+    }
+
     case event(LocalNotificationEventType)
-// TODO Katerina to fix calling state
-    case calling//calling(CallState)
+    case calling(CallState)
     case message(LocalNotificationContentType)
     case failedMessage
     case availabilityBehaviourChangeAlert(AvailabilityKind)

--- a/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Configuration.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Configuration.swift
@@ -66,7 +66,7 @@ private extension PushNotificationCategory {
     }
 
     init(callState: LocalNotificationType.CallState) {
-        switch (callState) {
+        switch callState {
         case .incomingCall:
             self = .incomingCall
         case .missedCall:

--- a/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Configuration.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Configuration.swift
@@ -28,15 +28,9 @@ extension LocalNotificationType {
 
     var sound: NotificationSound {
         switch self {
-// TODO Katerina fix it
-//        case .calling(let callState):
-//            switch callState {
-//            case .incoming:
-//                return .call
-//            default:
-//                return .newMessage
-//            }
-        case .calling:
+        case .calling(.incomingCall):
+            return .call
+        case .calling(.missedCall):
             return .newMessage
         case .event:
             return .newMessage
@@ -58,11 +52,8 @@ private extension PushNotificationCategory {
 
     init(notificationType: LocalNotificationType) {
         switch notificationType {
-           // TODO Katerina fix it
-//        case .calling(let callState):
-//            self.init(callState: callState)
-        case .calling:
-            self = .alert
+        case .calling(let callState):
+            self.init(callState: callState)
         case .event(let eventType):
             self.init(eventType: eventType)
         case .message(let contentType):
@@ -74,17 +65,14 @@ private extension PushNotificationCategory {
         }
     }
 
-    // TODO Katerina fix it
-//    init(callState: CallState) {
-//        switch (callState) {
-//        case .incoming:
-//            self = .incomingCall
-//        case .terminating(reason: .timeout):
-//            self = .missedCall
-//        default :
-//            self = .conversation
-//        }
-//    }
+    init(callState: LocalNotificationType.CallState) {
+        switch (callState) {
+        case .incomingCall:
+            self = .incomingCall
+        case .missedCall:
+            self = .missedCall
+        }
+    }
 
     init(eventType: LocalNotificationEventType) {
         switch eventType {

--- a/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -111,20 +111,17 @@ extension LocalNotificationType {
             case .messageTimerUpdate:
                 return ZMPushStringMessageTimerUpdate
             }
-        // TODO Katerina fix it
-//        case .calling(let callState):
-//            switch callState {
-//            case .incoming(video: true, shouldRing: _, degraded: _):
-//                return ZMPushStringVideoCallStarts
-//            case .incoming(video: false, shouldRing: _, degraded: _):
-//                return ZMPushStringCallStarts
-//            case .terminating, .none:
-//                return ZMPushStringCallMissed
-//            default:
-//                return ZMPushStringDefault
-//            }
-        case .calling:
-            return ZMPushStringDefault
+
+        case .calling(let callState):
+            switch callState {
+            case .incomingCall(video: true):
+                return ZMPushStringVideoCallStarts
+            case .incomingCall(video: false):
+                return ZMPushStringCallStarts
+            case .missedCall:
+                return ZMPushStringCallMissed
+            }
+
         case .event(let eventType):
             switch eventType {
             case .conversationCreated:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Calling notifications were commented out.

### Causes

This code was moved from sync engine to the request strategy and contains a reference to the `CallState`, which is defined in the sync engine.

### Solutions

Create a local `CallState` which will be passed in from the sync engine side.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
