### PR TITLE
feat: add notification for bundled messages SQSERVICES-1107

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -205,6 +205,9 @@
 "push.notification.alert.availability.away.message" = "Status affects notifications now. You’re set to “Away” and won’t receive any notifications.";
 "push.notification.alert.availability.busy.message" = "Status affects notifications now. You’re set to “Busy” and will only receive notifications when someone mentions you or replies to one of your messages.";
 
+// BUNDLED MESSAGES
+"push.notification.bundled-messages" = "%d new messages";
+
 // REACTIONS
 "push.notification.reaction.group" = "%1$@ %2$@ your message";
 "push.notification.reaction.group.nousername.noconversationname" = "Someone %@ your message in a conversation";

--- a/Sources/Notifications/Push Notifications/Notification Types/Content/BundledMessageNotificationBuilder.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Content/BundledMessageNotificationBuilder.swift
@@ -1,0 +1,49 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class BundledMessagesNotificationBuilder: NotificationBuilder {
+
+    var notificationType: LocalNotificationType {
+        return .bundledMessages
+    }
+
+    private let messageCount: Int
+
+    init(messageCount: Int) {
+        self.messageCount = messageCount
+    }
+
+    func shouldCreateNotification() -> Bool {
+        return true
+    }
+
+    func titleText() -> String? {
+        return nil
+    }
+
+    func bodyText() -> String {
+        return notificationType.bundledMessagesBodyText(messageCount: messageCount)
+    }
+
+    func userInfo() -> NotificationUserInfo? {
+        return nil
+    }
+
+}

--- a/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -33,6 +33,7 @@ public enum LocalNotificationType {
     case message(LocalNotificationContentType)
     case failedMessage
     case availabilityBehaviourChangeAlert(AvailabilityKind)
+    case bundledMessages
 }
 
 /// A notification builder provides the main components used to configure
@@ -219,6 +220,15 @@ extension LocalNotificationType {
         default:
             return false
         }
+    }
+
+}
+
+extension ZMLocalNotification {
+
+    public static func bundledMessages(count: Int, in context: NSManagedObjectContext) -> ZMLocalNotification? {
+        let builder = BundledMessagesNotificationBuilder(messageCount: count)
+        return ZMLocalNotification(builder: builder, moc: context)
     }
 
 }

--- a/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Configuration.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Configuration.swift
@@ -43,6 +43,8 @@ extension LocalNotificationType {
             }
         case .failedMessage, .availabilityBehaviourChangeAlert:
             return .newMessage
+        case .bundledMessages:
+            return .newMessage
         }
     }
 
@@ -62,6 +64,8 @@ private extension PushNotificationCategory {
             self = .conversation
         case .availabilityBehaviourChangeAlert:
             self = .alert
+        case .bundledMessages:
+            self = .conversation
         }
     }
 

--- a/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -45,6 +45,8 @@ private let ZMPushStringFailedToSend        = "failed.message"       // "Unable 
 
 private let ZMPushStringAlertAvailability   = "alert.availability"   // "Availability now affects notifications"
 
+private let ZMPushStringBundledMessages     = "bundled-messages"
+
 private let ZMPushStringMemberJoin          = "member.join"          // "[senderName] added you"
 private let ZMPushStringMemberLeave         = "member.leave"         // "[senderName] removed you"
 private let ZMPushStringMessageTimerUpdate  = "message-timer.update" // "[senderName] set the message timer to [duration]
@@ -137,8 +139,12 @@ extension LocalNotificationType {
             }
         case .failedMessage:
             return ZMPushStringFailedToSend
+
         case .availabilityBehaviourChangeAlert:
             return ZMPushStringAlertAvailability
+
+        case .bundledMessages:
+            return ZMPushStringBundledMessages
         }
     }
 
@@ -217,6 +223,11 @@ extension LocalNotificationType {
         let availabilityKey = availability == .away ? "away" : "busy"
         let localizationKey = [baseKey, availabilityKey, "message"].compactMap({ $0 }).joined(separator: ".")
         return .localizedStringWithFormat(localizationKey.pushFormatString)
+    }
+
+    func bundledMessagesBodyText(messageCount: Int) -> String {
+        guard case .bundledMessages = self else { return "" }
+        return .localizedStringWithFormat(baseKey.pushFormatString, arguments: [messageCount])
     }
 
     func messageBodyText(senderName: String?) -> String {

--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		BFF9446620F5F79F00531BC3 /* ImageV2DownloadRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF9446520F5F79F00531BC3 /* ImageV2DownloadRequestStrategyTests.swift */; };
 		D5D65A062073C8F800D7F3C3 /* AssetRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D65A052073C8F800D7F3C3 /* AssetRequestFactoryTests.swift */; };
 		D5D65A072074C23D00D7F3C3 /* AssetRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F963E8D91D955D4600098AD3 /* AssetRequestFactory.swift */; };
+		EE4C5FBE27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4C5FBD27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift */; };
 		EE82318927D22D79008CD77B /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82318827D22D79008CD77B /* String+Random.swift */; };
 		F14B7AEA222009BA00458624 /* UserRichProfileRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */; };
 		F14B7AEC222009C200458624 /* UserRichProfileRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B7AEB222009C200458624 /* UserRichProfileRequestStrategyTests.swift */; };
@@ -538,6 +539,7 @@
 		BF1F52C51ECC74E5002FB553 /* Array+RequestGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+RequestGenerator.swift"; sourceTree = "<group>"; };
 		BFF9446520F5F79F00531BC3 /* ImageV2DownloadRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageV2DownloadRequestStrategyTests.swift; sourceTree = "<group>"; };
 		D5D65A052073C8F800D7F3C3 /* AssetRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetRequestFactoryTests.swift; sourceTree = "<group>"; };
+		EE4C5FBD27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledMessageNotificationBuilder.swift; sourceTree = "<group>"; };
 		EE82318827D22D79008CD77B /* String+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
 		F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategy.swift; sourceTree = "<group>"; };
 		F14B7AEB222009C200458624 /* UserRichProfileRequestStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategyTests.swift; sourceTree = "<group>"; };
@@ -721,6 +723,7 @@
 			children = (
 				0649D12124F5C5EF001DDC78 /* ZMLocalNotification.swift */,
 				0649D19A24F66E9E001DDC78 /* ZMLocalNotification+Events.swift */,
+				EE4C5FBD27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift */,
 			);
 			path = Content;
 			sourceTree = "<group>";
@@ -1629,6 +1632,7 @@
 				16A4893F268B0C82001F9127 /* ClientMessageRequestStrategy.swift in Sources */,
 				F18401BD2073BE0800E9F4CC /* LinkPreviewAssetUploadRequestStrategy.swift in Sources */,
 				F18401AA2073BE0800E9F4CC /* FetchingClientRequestStrategy.swift in Sources */,
+				EE4C5FBE27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift in Sources */,
 				166901D61D7081C7000FE4AF /* ZMDownstreamObjectSyncWithWhitelist.m in Sources */,
 				16E70F8A270EEB2300718E5D /* PayloadProcessing+Conversation.swift in Sources */,
 				16E5F6D626EF1BE100F35FBA /* PaginatedSync.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1107" title="SQSERVICES-1107" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />SQSERVICES-1107</a>  Notification Service Extension
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The notification service extension can only display max one notification per push payload, but it's possible that we want to show more than one.

### Causes

When receiving the push payload, we trigger a fetch of the notification stream, which may return multiple events, each of which generate a local notification.

### Solutions

If there are more than one notification to show, we instead present a single notification for the bundled message events. This PR adds support for creating the bundled messages notification.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
