### PR TITLE
fix: can't send connection request FS-517

### DIFF
--- a/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandler.swift
+++ b/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandler.swift
@@ -53,7 +53,7 @@ class ConnectToUserActionHandler: ActionHandler<ConnectToUserAction> {
     func federatedRequest(for action: ActionHandler<ConnectToUserAction>.Action, apiVersion: APIVersion) -> ZMTransportRequest? {
         guard
             apiVersion > .v0,
-            let domain  = action.domain
+            let domain  = action.domain ?? APIVersion.domain
         else {
             Logging.network.error("Can't create request for connection request")
             return nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-517" title="FS-517" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-517</a>  [iOS] Can't send connection request with API versioning
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With api version v1 and federation disabled, nothing happens when I try to send a connection request.

### Causes

When using api v1, we use "federation aware" endpoints, which require a domain. When federation is disabled, we don't have any domains stored locally, so we are returning early when trying to create a request.

### Solutions

Add a fallback for getting the local domain via `APIVersion.domain`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
