### PR TITLE
fix: missing users under legal hold in conversation FS-535

### DIFF
--- a/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
@@ -32,12 +32,13 @@ public final class ClientMessageRequestFactory: NSObject {
     public func upstreamRequestForFetchingClients(conversationId: UUID,
                                                   domain: String?,
                                                   selfClient: UserClient,
-                                                  apiVersion: APIVersion) -> ZMTransportRequest? {
+                                                  apiVersion: APIVersion,
+                                                  forceLegacyEndpoint: Bool = false) -> ZMTransportRequest? {
         var path: String
         var message: SwiftProtobuf.Message
 
-        switch apiVersion {
-        case .v0:
+        switch (apiVersion, forceLegacyEndpoint) {
+        case (.v0, _), (_, true):
             path = "/" + ["conversations",
                           conversationId.transportString(),
                           "otr",
@@ -51,7 +52,7 @@ public final class ClientMessageRequestFactory: NSObject {
                 nativePush: false,
                 recipients: []
             )
-        case .v1:
+        case (.v1, false):
             guard let domain = domain ?? APIVersion.domain else {
                 zmLog.error("could not create request: missing domain")
                 return nil

--- a/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -80,7 +80,7 @@ extension VerifyLegalHoldRequestStrategy: IdentifierObjectSyncTranscoder {
               let selfClient = ZMUser.selfUser(in: managedObjectContext).selfClient()
         else { return nil }
 
-        return requestFactory.upstreamRequestForFetchingClients(conversationId: conversationID, domain: nil, selfClient: selfClient, apiVersion: apiVersion)
+        return requestFactory.upstreamRequestForFetchingClients(conversationId: conversationID, domain: nil, selfClient: selfClient, apiVersion: apiVersion, forceLegacyEndpoint: !APIVersion.isFederationEnabled)
     }
 
     public func didReceive(response: ZMTransportResponse, for identifiers: Set<ZMConversation>) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-535" title="FS-535" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-535</a>  [iOS] Legal hold regressions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->



----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In a conversation subject to legal hold, the other (not self) users under legal hold are missing from the legal hold view.

### Causes (Optional)

In order to know which users are under legal hold in the conversation, we create a request to fetch the missing clients (using the `ClientMessageRequestFactory`). We then parse the response and update the conversation's legal hold properties accordingly.

The cause of the issue resides in the payload we receive from the backend. When the api version is `v1`, we create a request to a federation enabled endpoint. The response we receive from this endpoint will have a different payload compared to the legacy payload. However, when parsing the response, we expect the payload to be the same as with the legacy endpoint. This is where it breaks.

### Solutions

**Proper solution:** decode the payload accordingly to the response's api version. Similarly to how it is done in the `CallingRequestStrategy` in the SE. 

**Quick solution:** make the request to the legacy endpoint instead of the federation enabled endpoint. This way we avoid updating the decoding and parsing logic.

Due to time constraints, this PR implements the **Quick solution**.
**Please note** that in the case where federation is enabled, this won't work.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
