### PR TITLE
fix: Create notifications for conversation create event SQSERVICES-1316

### DIFF
--- a/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Calling.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Calling.swift
@@ -31,17 +31,17 @@ public extension ZMLocalNotification {
 
         let callState: LocalNotificationType.CallState
         let caller: ZMUser
-        let conversation: ZMConversation
+        let conversation: ZMConversation?
         let managedObjectContext: NSManagedObjectContext
 
         var notificationType: LocalNotificationType {
             return .calling(callState)
         }
 
-        init?(callState: LocalNotificationType.CallState, caller: ZMUser, conversation: ZMConversation) {
+        init?(callState: LocalNotificationType.CallState, caller: ZMUser, conversation: ZMConversation?) {
             guard
-                let managedObjectContext = conversation.managedObjectContext,
-                conversation.remoteIdentifier != nil
+                let managedObjectContext = conversation?.managedObjectContext,
+                conversation?.remoteIdentifier != nil
             else {
                 return nil
             }
@@ -59,7 +59,7 @@ public extension ZMLocalNotification {
         }
 
         func shouldCreateNotification() -> Bool {
-            guard conversation.mutedMessageTypesIncludingAvailability != .all else { return false }
+            guard conversation?.mutedMessageTypesIncludingAvailability != .all else { return false }
             return true
         }
 
@@ -76,14 +76,14 @@ public extension ZMLocalNotification {
 
             guard let selfUserID = selfUser.remoteIdentifier,
                   let senderID = caller.remoteIdentifier,
-                  let conversationID = conversation.remoteIdentifier
+                  let conversationID = conversation?.remoteIdentifier
                   else { return nil }
 
             let userInfo = NotificationUserInfo()
             userInfo.selfUserID = selfUserID
             userInfo.senderID = senderID
             userInfo.conversationID = conversationID
-            userInfo.conversationName = conversation.meaningfulDisplayName
+            userInfo.conversationName = conversation?.meaningfulDisplayName
             userInfo.teamName = selfUser.team?.name
 
             return userInfo

--- a/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Calling.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Calling.swift
@@ -22,8 +22,11 @@ import WireDataModel
 
 public extension ZMLocalNotification {
 
-    convenience init?(callState: LocalNotificationType.CallState, conversation: ZMConversation, caller: ZMUser, moc: NSManagedObjectContext) {
-        guard let builder = CallNotificationBuilder(callState: callState, caller: caller, conversation: conversation) else { return nil }
+    convenience init?(callState: LocalNotificationType.CallState, conversation: ZMConversation?, caller: ZMUser, moc: NSManagedObjectContext) {
+        guard let conversation = conversation,
+              let builder = CallNotificationBuilder(callState: callState, caller: caller, conversation: conversation) else {
+                  return nil
+              }
         self.init(builder: builder, moc: moc)
     }
 
@@ -31,17 +34,17 @@ public extension ZMLocalNotification {
 
         let callState: LocalNotificationType.CallState
         let caller: ZMUser
-        let conversation: ZMConversation?
+        let conversation: ZMConversation
         let managedObjectContext: NSManagedObjectContext
 
         var notificationType: LocalNotificationType {
             return .calling(callState)
         }
 
-        init?(callState: LocalNotificationType.CallState, caller: ZMUser, conversation: ZMConversation?) {
+        init?(callState: LocalNotificationType.CallState, caller: ZMUser, conversation: ZMConversation) {
             guard
-                let managedObjectContext = conversation?.managedObjectContext,
-                conversation?.remoteIdentifier != nil
+                let managedObjectContext = conversation.managedObjectContext,
+                conversation.remoteIdentifier != nil
             else {
                 return nil
             }
@@ -59,7 +62,7 @@ public extension ZMLocalNotification {
         }
 
         func shouldCreateNotification() -> Bool {
-            guard conversation?.mutedMessageTypesIncludingAvailability != .all else { return false }
+            guard conversation.mutedMessageTypesIncludingAvailability != .all else { return false }
             return true
         }
 
@@ -76,14 +79,14 @@ public extension ZMLocalNotification {
 
             guard let selfUserID = selfUser.remoteIdentifier,
                   let senderID = caller.remoteIdentifier,
-                  let conversationID = conversation?.remoteIdentifier
+                  let conversationID = conversation.remoteIdentifier
                   else { return nil }
 
             let userInfo = NotificationUserInfo()
             userInfo.selfUserID = selfUserID
             userInfo.senderID = senderID
             userInfo.conversationID = conversationID
-            userInfo.conversationName = conversation?.meaningfulDisplayName
+            userInfo.conversationName = conversation.meaningfulDisplayName
             userInfo.teamName = selfUser.team?.name
 
             return userInfo

--- a/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -195,7 +195,7 @@ private class ConversationCreateEventNotificationBuilder: EventNotificationBuild
     }
 
     override func shouldCreateNotification() -> Bool {
-        return super.shouldCreateNotification() && conversation?.conversationType == .group
+        return super.shouldCreateNotification()
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
There are no notifications for create conversation events.

### Causes (Optional)
The `ConversationCreateEventNotificationBuilder` has a check for the conversationType, but at this point we don't have a conversation and this requirement is always false.

### Solutions
1. Remove an extra requirement from the `ConversationCreateEventNotificationBuilder`
2. Make conversation is optional for the ZMLocalNotification initialiser that will help in Notification engine.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
