### PR TITLE
feat: Add Crowdin github action SQSERVICES-1315

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,38 @@
+name: Crowdin Action
+
+on:
+  push:
+    branches: [ develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:      
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Crowdin action
+        uses: wireapp/github-action@1.4.8
+        with:
+          # For more info: https://github.com/crowdin/github-action/blob/master/action.yml
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }}          
+          token: ${{ secrets.CROWDIN_API_TOKEN }}
+          config: crowdin.yml
+          
+          upload_sources: true
+          download_translations: true
+          upload_translations: false
+
+          create_pull_request: true
+          localization_branch_name: chore/update-localization
+          commit_message: "chore: Update localization"
+          pull_request_title: "chore: Update localization SQPIT-786"
+          pull_request_body: "This PR pulls in the latest localization translations from Crowdin."
+          github_user_name: "zenkins"
+          github_user_email: "iosx@wire.com"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1315" title="SQSERVICES-1315" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQSERVICES-1315</a>  Move Crowdin support from sync engine to request strategy
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add a workflow for the GitHub Crowdin action.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
