### PR TITLE
chore: Re-enable tests SQSERVICES-1317

### DIFF
--- a/WireRequestStrategy.xcodeproj/xcshareddata/xcschemes/WireRequestStrategy.xcscheme
+++ b/WireRequestStrategy.xcodeproj/xcshareddata/xcschemes/WireRequestStrategy.xcscheme
@@ -57,9 +57,6 @@
                <Test
                   Identifier = "ZMLocalNotificationTests_Event/testThatItDoesntCreateConversationCreateNotification_OneToOne()">
                </Test>
-               <Test
-                  Identifier = "ZMLocalNotificationTests_Message">
-               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1317" title="SQSERVICES-1317" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQSERVICES-1317</a>  Re-enabled disabled tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

During the implementation of the Notification extension, the `ZMLocalNotificationTests_Message` tests were disabled. We can  re-enable them now. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
