### PR TITLE
chore: support api v2 for conversation endpoints FS-712

### DIFF
--- a/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
+++ b/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
@@ -129,10 +129,7 @@ public final class ClientMessageRequestFactory: NSObject {
     }
 
     public func requestToGetAsset(_ assetId: String, inConversation conversationId: UUID, apiVersion: APIVersion) -> ZMTransportRequest {
-        // TODO: GET /conversations/:conv/assets/:id and GET /conversations/:conv/otr/assets/:id have been removed.
-        // TODO: We should also have a switch over the api version here.
-        fatalError("API version not implemented")
-
+        guard apiVersion < .v2 else { fatalError("Endpoint not availale in API v2") }
         let path = "/" + ["conversations", conversationId.transportString(), "otr", "assets", assetId].joined(separator: "/")
         let request = ZMTransportRequest.imageGet(fromPath: path, apiVersion: apiVersion.rawValue)
         request.forceToBackgroundSession()
@@ -144,6 +141,7 @@ public final class ClientMessageRequestFactory: NSObject {
 // MARK: - Downloading
 extension ClientMessageRequestFactory {
     func downstreamRequestForEcryptedOriginalFileMessage(_ message: ZMAssetClientMessage, apiVersion: APIVersion) -> ZMTransportRequest? {
+        guard apiVersion < .v2 else { fatalError("Endpoint not availale in API v2") }
         guard let conversation = message.conversation, let identifier = conversation.remoteIdentifier else { return nil }
         let path = "/conversations/\(identifier.transportString())/otr/assets/\(message.assetId!.transportString())"
 

--- a/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
+++ b/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
@@ -39,20 +39,18 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
     override func request(for action: AddParticipantAction, apiVersion: APIVersion) -> ZMTransportRequest? {
         switch apiVersion {
         case .v0:
-            return nonFederatedRequest(for: action, apiVersion: apiVersion)
+            return v0Request(for: action)
         case .v1:
-            return federatedRequest(for: action, apiVersion: apiVersion)
+            return v1Request(for: action)
         case .v2:
-            // TODO : it should same as v1 but the path should be change(drop the suffix v2).
-            fatal("Api change needed")
+            return v2Request(for: action)
         }
     }
 
-    func nonFederatedRequest(for action: AddParticipantAction, apiVersion: APIVersion) -> ZMTransportRequest? {
+    private func v0Request(for action: AddParticipantAction) -> ZMTransportRequest? {
         var action = action
 
         guard
-            apiVersion == .v0,
             let conversation = ZMConversation.existingObject(for: action.conversationID, in: context),
             let conversationID = conversation.remoteIdentifier?.transportString(),
             let users: [ZMUser] = action.userIDs.existingObjects(in: context),
@@ -66,30 +64,55 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
         }
 
         let path = "/conversations/\(conversationID)/members"
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payloadAsString as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .methodPOST, payload: payloadAsString as ZMTransportData, apiVersion: 0)
     }
 
-    func federatedRequest(for action: AddParticipantAction, apiVersion: APIVersion) -> ZMTransportRequest? {
+    private func v1Request(for action: AddParticipantAction) -> ZMTransportRequest? {
         var action = action
 
         guard
-            apiVersion > .v0,
             let conversation = ZMConversation.existingObject(for: action.conversationID, in: context),
             let conversationID = conversation.qualifiedID,
+            let payload = payload(for: action)
+        else {
+            action.notifyResult(.failure(.unknown))
+            // Log error
+            return nil
+        }
+
+        let path = "/conversations/\(conversationID.uuid)/members/v2"
+        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload, apiVersion: 1)
+    }
+
+    private func v2Request(for action: AddParticipantAction) -> ZMTransportRequest? {
+        var action = action
+
+        guard
+            let conversation = ZMConversation.existingObject(for: action.conversationID, in: context),
+            let conversationID = conversation.qualifiedID,
+            let payload = payload(for: action)
+        else {
+            action.notifyResult(.failure(.unknown))
+            // Log error
+            return nil
+        }
+
+        let path = "/conversations/\(conversationID.domain)/\(conversationID.uuid)/members"
+        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload, apiVersion: 2)
+    }
+
+    private func payload(for action: AddParticipantAction) -> ZMTransportData? {
+        guard
             let users: [ZMUser] = action.userIDs.existingObjects(in: context),
             let qualifiedUserIDs = users.qualifiedUserIDs,
             let payload = Payload.ConversationAddMember(qualifiedUserIDs: qualifiedUserIDs),
             let payloadData = payload.payloadData(encoder: .defaultEncoder),
             let payloadAsString = String(bytes: payloadData, encoding: .utf8)
         else {
-            action.notifyResult(.failure(.unknown))
-            // Log error
             return nil
         }
-        // we are only passing uuid not the domainID
-        let path = "/conversations/\(conversationID.uuid)/members/v2"
 
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payloadAsString as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return payloadAsString as ZMTransportData
     }
 
     override func handleResponse(_ response: ZMTransportResponse, action: AddParticipantAction) {

--- a/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
+++ b/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
@@ -53,7 +53,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
 
     // MARK: - Request Generation
 
-    func testThatItCreatesARequestForAddingAParticipant_NonFederated() throws {
+    func testThatItCreatesARequestForAddingAParticipant_V0() throws {
         try syncMOC.performGroupedAndWait { _ in
             // given
             let userID = self.user.remoteIdentifier!
@@ -70,7 +70,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
         }
     }
 
-    func testThatItCreatesARequestForAddingAParticipant_Federated() throws {
+    func testThatItCreatesARequestForAddingAParticipant_V1() throws {
         try syncMOC.performGroupedAndWait { _ in
             // given
             let conversationID = self.conversation.remoteIdentifier!
@@ -81,6 +81,23 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/conversations/\(conversationID)/members/v2")
+            let payload = Payload.ConversationAddMember(request)
+            XCTAssertEqual(payload?.qualifiedUserIDs, [self.user.qualifiedID!])
+        }
+    }
+
+    func testThatItCreatesARequestForAddingAParticipant_V2() throws {
+        try syncMOC.performGroupedAndWait { _ in
+            // given
+            let conversationDomain = self.conversation.domain!
+            let conversationID = self.conversation.remoteIdentifier!
+            let action = AddParticipantAction(users: [self.user], conversation: self.conversation)
+
+            // when
+            let request = try XCTUnwrap(self.sut.request(for: action, apiVersion: .v2))
+
+            // then
+            XCTAssertEqual(request.path, "/v2/conversations/\(conversationDomain)/\(conversationID)/members")
             let payload = Payload.ConversationAddMember(request)
             XCTAssertEqual(payload?.qualifiedUserIDs, [self.user.qualifiedID!])
         }

--- a/Sources/Request Strategies/Conversation/ConversationByQualifiedIDListTranscoderTests.swift
+++ b/Sources/Request Strategies/Conversation/ConversationByQualifiedIDListTranscoderTests.swift
@@ -1,0 +1,62 @@
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireRequestStrategy
+import Foundation
+
+class ConversationByQualifiedIDListTranscoderTests: MessagingTestBase {
+
+    // MARK: - Request generation
+
+    func testRequestGeneration_V1() throws {
+        // Given
+        let sut = ConversationByQualifiedIDListTranscoder(context: uiMOC)
+        let ids: [QualifiedID] = [QualifiedID(uuid: .create(), domain: "example.com")]
+
+        // When
+        let request = try XCTUnwrap(sut.request(for: Set(ids), apiVersion: .v1))
+
+        // Then
+        XCTAssertEqual(request.path, "/v1/conversations/list/v2")
+        XCTAssertEqual(request.method, .methodPOST)
+
+        let payloadString = try XCTUnwrap(request.payload as? String)
+        let payloadData = try XCTUnwrap(payloadString.data(using: .utf8))
+        let payload = Payload.QualifiedUserIDList(payloadData)
+        XCTAssertEqual(payload, Payload.QualifiedUserIDList(qualifiedIDs: ids))
+    }
+
+    func testRequestGeneration_V2() throws {
+        // Given
+        let sut = ConversationByQualifiedIDListTranscoder(context: uiMOC)
+        let ids: [QualifiedID] = [QualifiedID(uuid: .create(), domain: "example.com")]
+
+        // When
+        let request = try XCTUnwrap(sut.request(for: Set(ids), apiVersion: .v2))
+
+        // Then
+        XCTAssertEqual(request.path, "/v2/conversations/list")
+        XCTAssertEqual(request.method, .methodPOST)
+
+        let payloadString = try XCTUnwrap(request.payload as? String)
+        let payloadData = try XCTUnwrap(payloadString.data(using: .utf8))
+        let payload = Payload.QualifiedUserIDList(payloadData)
+        XCTAssertEqual(payload, Payload.QualifiedUserIDList(qualifiedIDs: ids))
+    }
+
+}

--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		EE202DAB27F1F4CC00083AB3 /* VoIPPushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE202DAA27F1F4CC00083AB3 /* VoIPPushPayload.swift */; };
 		EE3245FC2821D41000F2A84A /* VoIPPushHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3245FB2821D41000F2A84A /* VoIPPushHelper.swift */; };
 		EE3246042823196100F2A84A /* VoIPPushHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3246032823196100F2A84A /* VoIPPushHelperTests.swift */; };
+		EE4345DF2865D0FB0090AC34 /* ConversationByQualifiedIDListTranscoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4345DE2865D0FB0090AC34 /* ConversationByQualifiedIDListTranscoderTests.swift */; };
 		EE4C5FBE27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4C5FBD27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift */; };
 		EE82318927D22D79008CD77B /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82318827D22D79008CD77B /* String+Random.swift */; };
 		EE90C29E282E785800474379 /* PushTokenStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE90C29D282E785800474379 /* PushTokenStrategy.swift */; };
@@ -571,6 +572,7 @@
 		EE202DAA27F1F4CC00083AB3 /* VoIPPushPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoIPPushPayload.swift; sourceTree = "<group>"; };
 		EE3245FB2821D41000F2A84A /* VoIPPushHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoIPPushHelper.swift; sourceTree = "<group>"; };
 		EE3246032823196100F2A84A /* VoIPPushHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoIPPushHelperTests.swift; sourceTree = "<group>"; };
+		EE4345DE2865D0FB0090AC34 /* ConversationByQualifiedIDListTranscoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationByQualifiedIDListTranscoderTests.swift; sourceTree = "<group>"; };
 		EE4C5FBD27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledMessageNotificationBuilder.swift; sourceTree = "<group>"; };
 		EE82318827D22D79008CD77B /* String+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
 		EE90C29D282E785800474379 /* PushTokenStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTokenStrategy.swift; sourceTree = "<group>"; };
@@ -898,6 +900,7 @@
 				168D7CB526FB0E7000789960 /* Actions */,
 				1658EA6126DE22C0003D0090 /* ConversationRequestStrategy.swift */,
 				16E5F71726EF4DBF00F35FBA /* ConversationRequestStrategyTests.swift */,
+				EE4345DE2865D0FB0090AC34 /* ConversationByQualifiedIDListTranscoderTests.swift */,
 			);
 			path = Conversation;
 			sourceTree = "<group>";
@@ -1917,6 +1920,7 @@
 				5E9EA4E02243C6B200D401B2 /* LinkAttachmentsPreprocessorTests.swift in Sources */,
 				06FDC63128354DBD008300DB /* PushTokenStorageTests.swift in Sources */,
 				F18401EE2073C26C00E9F4CC /* LinkPreviewAssetUploadRequestStrategyTests.swift in Sources */,
+				EE4345DF2865D0FB0090AC34 /* ConversationByQualifiedIDListTranscoderTests.swift in Sources */,
 				06474D6024B310B6002C695D /* NotificationsTrackerTests.swift in Sources */,
 				0693114A24F799F400D14DF5 /* ZMLocalNotificationTests.swift in Sources */,
 				F18401EA2073C26700E9F4CC /* AbstractRequestStrategyTests.swift in Sources */,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Changes for API version 2 for `/conversations` endpoints.

### Testing

#### Test Coverage

- Unit tests for asserting v2 requests.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
