### PR TITLE
chore: Drop forceVoipSession

### DIFF
--- a/Sources/Helpers/AssetRequestFactory.swift
+++ b/Sources/Helpers/AssetRequestFactory.swift
@@ -66,7 +66,7 @@ public final class AssetRequestFactory: NSObject {
     }
 
     func dataForMultipartAssetUploadRequest(_ data: Data, shareable: Bool, retention: Retention) throws -> Data {
-        let fileDataHeader = [Constant.md5: (data as NSData).zmMD5Digest().base64String()]
+        let fileDataHeader = [Constant.md5: (data as Data).zmMD5Digest().base64String()]
         let jsonObject: [String: Any] = [
             Constant.accessLevel: shareable,
             Constant.retention: retention.rawValue

--- a/Sources/Helpers/AssetRequestFactory.swift
+++ b/Sources/Helpers/AssetRequestFactory.swift
@@ -66,7 +66,7 @@ public final class AssetRequestFactory: NSObject {
     }
 
     func dataForMultipartAssetUploadRequest(_ data: Data, shareable: Bool, retention: Retention) throws -> Data {
-        let fileDataHeader = [Constant.md5: (data as Data).zmMD5Digest().base64String()]
+        let fileDataHeader = [Constant.md5: (data).zmMD5Digest().base64String()]
         let jsonObject: [String: Any] = [
             Constant.accessLevel: shareable,
             Constant.retention: retention.rawValue

--- a/Sources/Notifications/NotificationStreamSync.swift
+++ b/Sources/Notifications/NotificationStreamSync.swift
@@ -56,7 +56,6 @@ public class NotificationStreamSync: NSObject, ZMRequestGenerator, ZMSimpleListR
             return nil
         }
 
-        request.forceToVoipSession()
         notificationsTracker?.registerStartStreamFetching()
         request.add(ZMCompletionHandler(on: self.managedObjectContext, block: { _ in
             self.notificationsTracker?.registerFinishStreamFetching()

--- a/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -108,7 +108,6 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
             request = requestsFactory.fetchPrekeysFederated(for: missing, apiVersion: apiVersion)
         }
 
-        request?.transportRequest.forceToVoipSession()
         return request
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we drop the forceVoipSession because it has been deprecated and we can't use it anymore.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
