### PR TITLE
chore: restore PUT /connection/:domain/:user FS-801

### DIFF
--- a/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandler.swift
+++ b/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandler.swift
@@ -27,11 +27,8 @@ class UpdateConnectionActionHandler: ActionHandler<UpdateConnectionAction> {
         case .v0:
             return v0Request(for: action)
 
-        case .v1:
+        case .v1, .v2:
             return v1Request(for: action)
-
-        case .v2:
-            return v2Request(for: action)
         }
     }
 
@@ -68,24 +65,6 @@ class UpdateConnectionActionHandler: ActionHandler<UpdateConnectionAction> {
             method: .methodPUT,
             payload: payload,
             apiVersion: 1
-        )
-    }
-
-    private func v2Request(for action: UpdateConnectionAction) -> ZMTransportRequest? {
-        guard
-            let connection = ZMConnection.existingObject(for: action.connectionID, in: context),
-            let qualifiedID = connection.to.qualifiedID,
-            let payload = payload(from: action)
-        else {
-            Logging.network.error("Can't create request to update connection status")
-            return nil
-        }
-
-        return ZMTransportRequest(
-            path: "/connections/\(qualifiedID.domain)/\(qualifiedID.uuid.transportString())",
-            method: .methodPOST,
-            payload: payload,
-            apiVersion: 2
         )
     }
 

--- a/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandlerTests.swift
+++ b/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandlerTests.swift
@@ -72,24 +72,6 @@ class UpdateConnectionActionHandlerTests: MessagingTestBase {
         }
     }
 
-    func testThatItCreatesARequestForUpdatingConnection_APIV2() throws {
-        try syncMOC.performGroupedAndWait { _ in
-            // given
-            let userID = self.oneToOneConversation.connection!.to.qualifiedID!
-            let action = UpdateConnectionAction(connection: self.oneToOneConversation.connection!,
-                                                newStatus: .cancelled)
-
-            // when
-            let request = try XCTUnwrap(self.sut.request(for: action, apiVersion: .v2))
-
-            // then
-            XCTAssertEqual(request.path, "/v2/connections/\(userID.domain)/\(userID.uuid.transportString())")
-            XCTAssertEqual(request.method, .methodPOST)
-            let payload = Payload.ConnectionUpdate(request)
-            XCTAssertEqual(payload?.status, .cancelled)
-        }
-    }
-
     // MARK: - Request Processing
 
     func testThatItParsesAllKnownConnectionUpdateErrorResponses() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-801" title="FS-801" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-801</a>  [iOS] Bring back PUT endpoint for /connections
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

`PUT /connections/:domain/:user` was restored for v2, which is the same behavior for v1, so I removed the change we made earlier.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
