### PR TITLE
feat(mls): support calling in MLS groups FS-675

### DIFF
--- a/Sources/Helpers/ZMTransportResponse+ErrorInfo.swift
+++ b/Sources/Helpers/ZMTransportResponse+ErrorInfo.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMTransportResponse {
+
+    var errorInfo: (status: Int, label: String, message: String) {
+        let payload = self.payload?.asDictionary()
+        let label = payload?["label"] as? String
+        let message = payload?["message"] as? String
+        return (httpStatus, label ?? "?", message ?? "?")
+    }
+
+}

--- a/Sources/Notifications/CallEventContent.swift
+++ b/Sources/Notifications/CallEventContent.swift
@@ -87,6 +87,14 @@ public struct CallEventContent: Decodable {
         return type == "REMOTEMUTE"
     }
 
+    public var isConferenceKey: Bool {
+        return type == "CONFKEY"
+    }
+
+    public var isReject: Bool {
+        return type == "REJECT"
+    }
+
 }
 
 extension CallEventContent {

--- a/Sources/Notifications/CallEventContent.swift
+++ b/Sources/Notifications/CallEventContent.swift
@@ -23,11 +23,9 @@ public struct CallEventContent: Decodable {
     private enum CodingKeys: String, CodingKey {
 
         case type
-
         case properties = "props"
-
-        case callerIdString = "src_userid"
-
+        case callerUserID = "src_userid"
+        case callerClientID = "src_clientid"
         case resp
 
     }
@@ -42,9 +40,9 @@ public struct CallEventContent: Decodable {
 
     let properties: Properties?
 
-    /// Caller Id.
+    let callerUserID: String
 
-    let callerIdString: String
+    public let callerClientID: String
 
     let resp: Bool
 
@@ -62,7 +60,7 @@ public struct CallEventContent: Decodable {
     // MARK: - Methods
 
     public var callerID: UUID? {
-        return UUID(uuidString: callerIdString)
+        return UUID(uuidString: callerUserID)
     }
 
     public var callState: LocalNotificationType.CallState? {

--- a/Sources/Notifications/CallEventContentTests.swift
+++ b/Sources/Notifications/CallEventContentTests.swift
@@ -36,7 +36,7 @@ class CallEventContentTests: XCTestCase {
         let json: [String: Any] = [
             "type": type,
             "src_userid": callerID.uuidString,
-            "src_clientid": "cliendid",
+            "src_clientid": "clientid",
             "resp": resp,
             "props": ["videosend": "\(isVideo)"]
         ]

--- a/Sources/Notifications/CallEventContentTests.swift
+++ b/Sources/Notifications/CallEventContentTests.swift
@@ -36,6 +36,7 @@ class CallEventContentTests: XCTestCase {
         let json: [String: Any] = [
             "type": type,
             "src_userid": callerID.uuidString,
+            "src_clientid": "cliendid",
             "resp": resp,
             "props": ["videosend": "\(isVideo)"]
         ]

--- a/Sources/Object Syncs/Helpers/MLSMessage.swift
+++ b/Sources/Object Syncs/Helpers/MLSMessage.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// A message that can be sent in an mls group.
 
-protocol MLSMessage: OTREntity, MLSEncryptedPayloadGenerator, Hashable {}
+public protocol MLSMessage: OTREntity, MLSEncryptedPayloadGenerator, Hashable {}
 
 extension ZMClientMessage: MLSMessage {}
 

--- a/Sources/Object Syncs/Helpers/MessageSync.swift
+++ b/Sources/Object Syncs/Helpers/MessageSync.swift
@@ -24,9 +24,9 @@ import Foundation
 /// This sync ensures that each message is sent to the backend using the appropriate
 /// protocol.
 
-class MessageSync<Message: ProteusMessage & MLSMessage>: NSObject, ZMContextChangeTrackerSource, ZMRequestGenerator {
+public class MessageSync<Message: ProteusMessage & MLSMessage>: NSObject, ZMContextChangeTrackerSource, ZMRequestGenerator {
 
-    typealias OnRequestScheduledHandler = (_ message: Message, _ request: ZMTransportRequest) -> Void
+    public typealias OnRequestScheduledHandler = (_ message: Message, _ request: ZMTransportRequest) -> Void
 
     // MARK: - Properties
 
@@ -35,7 +35,7 @@ class MessageSync<Message: ProteusMessage & MLSMessage>: NSObject, ZMContextChan
 
     // MARK: - Life cycle
 
-    init(context: NSManagedObjectContext, appStatus: ApplicationStatus) {
+    public init(context: NSManagedObjectContext, appStatus: ApplicationStatus) {
         proteusMessageSync = ProteusMessageSync(
             context: context,
             applicationStatus: appStatus
@@ -46,24 +46,24 @@ class MessageSync<Message: ProteusMessage & MLSMessage>: NSObject, ZMContextChan
 
     // MARK: - Change tracker
 
-    var contextChangeTrackers: [ZMContextChangeTracker] {
+    public var contextChangeTrackers: [ZMContextChangeTracker] {
         return proteusMessageSync.contextChangeTrackers + mlsMessageSync.contextChangeTrackers
     }
 
     // MARK: - Request generator
 
-    func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest? {
+    public func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest? {
         return [proteusMessageSync, mlsMessageSync].nextRequest(for: apiVersion)
     }
 
     // MARK: - Methods
 
-    func onRequestScheduled(_ handler: @escaping OnRequestScheduledHandler) {
+    public func onRequestScheduled(_ handler: @escaping OnRequestScheduledHandler) {
         proteusMessageSync.onRequestScheduled(handler)
         mlsMessageSync.onRequestScheduled(handler)
     }
 
-    func sync(_ message: Message, completion: @escaping EntitySyncHandler) {
+    public func sync(_ message: Message, completion: @escaping EntitySyncHandler) {
         guard let conversation = message.conversation else {
             Logging.messageProcessing.warn("failed to sync message b/c message protocol can't be determined")
             completion(.failure(.messageProtocolMissing), .init())
@@ -79,7 +79,7 @@ class MessageSync<Message: ProteusMessage & MLSMessage>: NSObject, ZMContextChan
         }
     }
 
-    func expireMessages(withDependency dependency: NSObject) {
+    public func expireMessages(withDependency dependency: NSObject) {
         proteusMessageSync.expireMessages(withDependency: dependency)
         mlsMessageSync.expireMessages(withDependency: dependency)
     }

--- a/Sources/Payloads/Payload+Decoding.swift
+++ b/Sources/Payloads/Payload+Decoding.swift
@@ -81,7 +81,17 @@ extension Decodable {
 
 extension Encodable {
 
-    /// Encode object to binary payload and log an error if it fails
+    /// Encode object to string payload and log an error if it fails.
+    ///
+    /// - parameter encoder: JSONEncoder to use
+
+    func payloadString(encoder: JSONEncoder = .defaultEncoder) -> String? {
+        return payloadData(encoder: encoder).flatMap {
+            String(data: $0, encoding: .utf8)
+        }
+    }
+
+    /// Encode object to binary payload and log an error if it fails.
     ///
     /// - parameter encoder: JSONEncoder to use
 

--- a/Sources/Payloads/Payload.swift
+++ b/Sources/Payloads/Payload.swift
@@ -52,7 +52,7 @@ enum Payload {
         let id: Int?
     }
 
-    struct Location: Codable {
+    struct Location: Codable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case longitude = "lon"
@@ -63,7 +63,7 @@ enum Payload {
         let latitide: Double
     }
 
-    struct UserClient: Codable {
+    struct UserClient: Codable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case id
@@ -84,7 +84,7 @@ enum Payload {
         let deviceModel: String?
 
         init(id: String,
-             deviceClass: String,
+             deviceClass: String? = nil,
              type: String? = nil,
              creationDate: Date? = nil,
              label: String? = nil,

--- a/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
@@ -24,6 +24,12 @@ public struct QualifiedClientID: Hashable {
     public let domain: String
     public let clientID: String
 
+    public init(userID: UUID, domain: String, clientID: String) {
+        self.userID = userID
+        self.domain = domain
+        self.clientID = clientID
+    }
+
 }
 
 /// An action to fetch all user client IDs given a set of

--- a/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
@@ -29,9 +29,9 @@ public final class FetchUserClientsAction: EntityAction {
 
     public struct QualifiedClientID: Hashable {
 
-        let userID: UUID
-        let domain: String
-        let clientID: String
+        public let userID: UUID
+        public let domain: String
+        public let clientID: String
 
     }
 

--- a/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
@@ -1,0 +1,64 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// An action to fetch all user client IDs given a set of
+/// user IDs.
+
+public final class FetchUserClientsAction: EntityAction {
+
+    // MARK: - Types
+
+    public typealias Result = Set<QualifiedClientID>
+
+    public struct QualifiedClientID: Hashable {
+
+        let userID: UUID
+        let domain: String
+        let clientID: String
+
+    }
+
+    public enum Failure: Error, Equatable {
+
+        case endpointUnavailable
+        case malformdRequestPayload
+        case failedToEncodeRequestPayload
+        case missingResponsePayload
+        case failedToDecodeResponsePayload
+        case unknown(status: Int, label: String, message: String)
+
+    }
+
+    // MARK: - Properties
+
+    public let userIDs: Set<QualifiedID>
+    public var resultHandler: ResultHandler?
+
+    // MARK: - Life cycle
+
+    public init(
+        userIDs: Set<QualifiedID>,
+        resultHandler: ResultHandler? = nil
+    ) {
+        self.userIDs = userIDs
+        self.resultHandler = resultHandler
+    }
+
+}

--- a/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsAction.swift
@@ -18,6 +18,14 @@
 
 import Foundation
 
+public struct QualifiedClientID: Hashable {
+
+    public let userID: UUID
+    public let domain: String
+    public let clientID: String
+
+}
+
 /// An action to fetch all user client IDs given a set of
 /// user IDs.
 
@@ -26,14 +34,6 @@ public final class FetchUserClientsAction: EntityAction {
     // MARK: - Types
 
     public typealias Result = Set<QualifiedClientID>
-
-    public struct QualifiedClientID: Hashable {
-
-        public let userID: UUID
-        public let domain: String
-        public let clientID: String
-
-    }
 
     public enum Failure: Error, Equatable {
 

--- a/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
@@ -101,7 +101,7 @@ final class FetchUserClientsActionHandler: ActionHandler<FetchUserClientsAction>
                         }
 
                         result.formUnion(clients.map { client in
-                            Action.QualifiedClientID(
+                            QualifiedClientID(
                                 userID: userID,
                                 domain: domain,
                                 clientID: client.id

--- a/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
@@ -124,14 +124,3 @@ final class FetchUserClientsActionHandler: ActionHandler<FetchUserClientsAction>
     }
 
 }
-
-extension ZMTransportResponse {
-
-    var errorInfo: (status: Int, label: String, message: String) {
-        let payload = self.payload?.asDictionary()
-        let label = payload?["label"] as? String
-        let message = payload?["message"] as? String
-        return (httpStatus, label ?? "?", message ?? "?")
-    }
-
-}

--- a/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
@@ -1,0 +1,137 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class FetchUserClientsActionHandler: ActionHandler<FetchUserClientsAction> {
+
+    // MARK: - Request
+
+    struct RequestPayload: Codable, Equatable {
+
+        let qualified_users: Set<QualifiedID>
+
+    }
+
+    override func request(
+        for action: FetchUserClientsAction,
+        apiVersion: APIVersion
+    ) -> ZMTransportRequest? {
+        var action = action
+
+        switch apiVersion {
+        case .v0:
+            action.fail(with: .endpointUnavailable)
+            return nil
+
+        case .v1, .v2:
+            guard
+                let payloadData = RequestPayload(qualified_users: action.userIDs).payloadData(),
+                let payloadString = String(bytes: payloadData, encoding: .utf8)
+            else {
+                action.fail(with: .failedToEncodeRequestPayload)
+                return nil
+            }
+
+            return ZMTransportRequest(
+                path: "/users/list-clients",
+                method: .methodPOST,
+                payload: payloadString as ZMTransportData,
+                apiVersion: apiVersion.rawValue
+            )
+        }
+    }
+
+    // MARK: - Response
+
+    struct ResponsePayload: Codable, Equatable {
+
+        let qualified_user_map: Payload.UserClientByDomain
+
+    }
+
+    override func handleResponse(
+        _ response: ZMTransportResponse,
+        action: FetchUserClientsAction
+    ) {
+        guard let apiVersion = APIVersion(rawValue: response.apiVersion) else {
+            return
+        }
+
+        var action = action
+
+        switch apiVersion {
+        case .v0:
+            return
+
+        case .v1, .v2:
+            switch response.httpStatus {
+            case 200:
+                guard let rawData = response.rawData else {
+                    action.fail(with: .missingResponsePayload)
+                    return
+                }
+
+                guard let payload = ResponsePayload(rawData) else {
+                    action.fail(with: .failedToDecodeResponsePayload)
+                    return
+                }
+
+                var result = FetchUserClientsAction.Result()
+
+                for (domain, users) in payload.qualified_user_map {
+                    for (userID, clients) in users {
+                        guard let userID = UUID(uuidString: userID) else {
+                            continue
+                        }
+
+                        result.formUnion(clients.map { client in
+                            Action.QualifiedClientID(
+                                userID: userID,
+                                domain: domain,
+                                clientID: client.id
+                            )
+                        })
+                    }
+                }
+
+                action.succeed(with: result)
+
+            case 400:
+                action.fail(with: .malformdRequestPayload)
+
+            default:
+                let errorInfo = response.errorInfo
+                action.fail(with: .unknown(status: errorInfo.status, label: errorInfo.label, message: errorInfo.message))
+            }
+
+        }
+    }
+
+}
+
+extension ZMTransportResponse {
+
+    var errorInfo: (status: Int, label: String, message: String) {
+        let payload = self.payload?.asDictionary()
+        let label = payload?["label"] as? String
+        let message = payload?["message"] as? String
+        return (httpStatus, label ?? "?", message ?? "?")
+    }
+
+}

--- a/Sources/Request Strategies/User Clients/FetchUserClientsActionHandlerTests.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsActionHandlerTests.swift
@@ -118,17 +118,17 @@ class FetchUserClientsActionHandlerTests: ActionHandlerTestBase<FetchUserClients
 
         // Then
         XCTAssertEqual(result, Set([
-            FetchUserClientsAction.QualifiedClientID(
+            QualifiedClientID(
                 userID: userID1,
                 domain: domain1,
                 clientID: clientID1
             ),
-            FetchUserClientsAction.QualifiedClientID(
+            QualifiedClientID(
                 userID: userID1,
                 domain: domain1,
                 clientID: clientID2
             ),
-            FetchUserClientsAction.QualifiedClientID(
+            QualifiedClientID(
                 userID: userID2,
                 domain: domain2,
                 clientID: clientID3

--- a/Sources/Request Strategies/User Clients/FetchUserClientsActionHandlerTests.swift
+++ b/Sources/Request Strategies/User Clients/FetchUserClientsActionHandlerTests.swift
@@ -1,0 +1,173 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireRequestStrategy
+
+class FetchUserClientsActionHandlerTests: ActionHandlerTestBase<FetchUserClientsAction, FetchUserClientsActionHandler> {
+
+    typealias RequestPayload = FetchUserClientsActionHandler.RequestPayload
+    typealias ResponsePayload = FetchUserClientsActionHandler.ResponsePayload
+
+    // MARK: - Properties
+
+    let userID1 = UUID.create()
+    let domain1 = "foo.com"
+    let clientID1 = "client1"
+    let clientID2 = "client2"
+
+    let userID2 = UUID.create()
+    let domain2 = "bar.com"
+    let clientID3 = "client3"
+
+    // MARK: - Setup
+
+    override func setUp() {
+        super.setUp()
+        action = FetchUserClientsAction(userIDs: Set([
+            QualifiedID(uuid: userID1, domain: domain1),
+            QualifiedID(uuid: userID2, domain: domain2)
+        ]))
+    }
+
+    override func tearDown() {
+        action = nil
+        super.tearDown()
+    }
+
+    // MARK: - Request generation
+
+    func test_itGenerateARequest_APIV2() throws {
+        // Given
+        let expectedPayload = try XCTUnwrap(RequestPayload(qualified_users: action.userIDs).payloadString())
+
+        // Then
+        try test_itGeneratesARequest(
+            for: action,
+            expectedPath: "/v2/users/list-clients",
+            expectedPayload: expectedPayload,
+            expectedMethod: .methodPOST,
+            apiVersion: .v2
+        )
+    }
+
+    func test_itGenerateARequest_APIV1() throws {
+        // Given
+        let expectedPayload = try XCTUnwrap(RequestPayload(qualified_users: action.userIDs).payloadString())
+
+        // Then
+        try test_itGeneratesARequest(
+            for: action,
+            expectedPath: "/v1/users/list-clients",
+            expectedPayload: expectedPayload,
+            expectedMethod: .methodPOST,
+            apiVersion: .v1
+        )
+    }
+
+    func test_itFailsToGenerateRequest_APIV0() {
+        // Then
+        test_itDoesntGenerateARequest(
+            action: action,
+            apiVersion: .v0,
+            expectedError: .endpointUnavailable
+        )
+    }
+
+    // MARK: - Response handling
+
+    func test_itHandlesResponse_200() throws {
+        // Given
+        let payload = ResponsePayload(qualified_user_map: [
+            domain1: [
+                userID1.uuidString: [
+                    Payload.UserClient(id: clientID1),
+                    Payload.UserClient(id: clientID2)
+                ]
+            ],
+            domain2: [
+                userID2.uuidString: [
+                    Payload.UserClient(id: clientID3)
+                ]
+            ]
+        ])
+
+        let payloadString = try XCTUnwrap(payload.payloadString())
+
+        // When
+        let result = test_itHandlesSuccess(
+            status: 200,
+            payload: payloadString as ZMTransportData
+        )
+
+        // Then
+        XCTAssertEqual(result, Set([
+            FetchUserClientsAction.QualifiedClientID(
+                userID: userID1,
+                domain: domain1,
+                clientID: clientID1
+            ),
+            FetchUserClientsAction.QualifiedClientID(
+                userID: userID1,
+                domain: domain1,
+                clientID: clientID2
+            ),
+            FetchUserClientsAction.QualifiedClientID(
+                userID: userID2,
+                domain: domain2,
+                clientID: clientID3
+            )
+        ]))
+    }
+
+    func test_itHandlesResponse_200_FailedToDecode() throws {
+        // When
+        test_itHandlesResponse(
+            action: action,
+            status: 200,
+            payload: ["foo": "bar"] as ZMTransportData,
+            apiVersion: .v1
+        ) { result in
+            // Then
+            guard case .failure(.failedToDecodeResponsePayload) = result else {
+                XCTFail("unexpected result: \(String(describing: result))")
+                return false
+            }
+
+            return true
+        }
+    }
+
+    func test_itHandlesResponse_400_MalformedRequestPayload() throws {
+        test_itHandlesFailure(
+            status: 400,
+            label: nil,
+            expectedError: .malformdRequestPayload
+        )
+    }
+
+    func test_itHandlesResponse_Unknown() throws {
+        test_itHandlesFailure(
+            status: 999,
+            label: "foo",
+            expectedError: .unknown(status: 999, label: "foo", message: "?")
+        )
+    }
+
+}

--- a/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -47,6 +47,8 @@ public final class FetchingClientRequestStrategy: AbstractRequestStrategy {
     var userClientByUserClientIDTranscoder: UserClientByUserClientIDTranscoder
     var userClientByQualifiedUserIDTranscoder: UserClientByQualifiedUserIDTranscoder
 
+    private let entitySync: EntityActionSync
+
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
 
         self.userClientByUserIDTranscoder = UserClientByUserIDTranscoder(managedObjectContext: managedObjectContext)
@@ -56,6 +58,10 @@ public final class FetchingClientRequestStrategy: AbstractRequestStrategy {
         self.userClientsByUserID = IdentifierObjectSync(managedObjectContext: managedObjectContext, transcoder: userClientByUserIDTranscoder)
         self.userClientsByUserClientID = IdentifierObjectSync(managedObjectContext: managedObjectContext, transcoder: userClientByUserClientIDTranscoder)
         self.userClientsByQualifiedUserID = IdentifierObjectSync(managedObjectContext: managedObjectContext, transcoder: userClientByQualifiedUserIDTranscoder)
+
+        entitySync = EntityActionSync(actionHandlers: [
+            FetchUserClientsActionHandler(context: managedObjectContext)
+        ])
 
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
 
@@ -107,7 +113,8 @@ public final class FetchingClientRequestStrategy: AbstractRequestStrategy {
         return
             userClientsByUserClientID.nextRequest(for: apiVersion) ??
             userClientsByUserID.nextRequest(for: apiVersion) ??
-            userClientsByQualifiedUserID.nextRequest(for: apiVersion)
+            userClientsByQualifiedUserID.nextRequest(for: apiVersion) ??
+            entitySync.nextRequest(for: apiVersion)
     }
 
 }

--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -248,6 +248,7 @@
 		EEE0EDB12858906500BBEE29 /* MLSRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0EDB02858906500BBEE29 /* MLSRequestStrategy.swift */; };
 		EEE0EE0528591D3200BBEE29 /* OptionalString+NonEmptyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0EE0328591D2C00BBEE29 /* OptionalString+NonEmptyValue.swift */; };
 		EEE0EE0728591E9C00BBEE29 /* AssetDownloadRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0EE0628591E9C00BBEE29 /* AssetDownloadRequestFactoryTests.swift */; };
+		EEE46E5428C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE46E5328C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift */; };
 		F14B7AEA222009BA00458624 /* UserRichProfileRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */; };
 		F14B7AEC222009C200458624 /* UserRichProfileRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B7AEB222009C200458624 /* UserRichProfileRequestStrategyTests.swift */; };
 		F154EDC71F447B6C00CB8184 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F154EDC61F447B6C00CB8184 /* AppDelegate.swift */; };
@@ -649,6 +650,7 @@
 		EEE0EDB02858906500BBEE29 /* MLSRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSRequestStrategy.swift; sourceTree = "<group>"; };
 		EEE0EE0328591D2C00BBEE29 /* OptionalString+NonEmptyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionalString+NonEmptyValue.swift"; sourceTree = "<group>"; };
 		EEE0EE0628591E9C00BBEE29 /* AssetDownloadRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDownloadRequestFactoryTests.swift; sourceTree = "<group>"; };
+		EEE46E5328C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMTransportResponse+ErrorInfo.swift"; sourceTree = "<group>"; };
 		F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategy.swift; sourceTree = "<group>"; };
 		F14B7AEB222009C200458624 /* UserRichProfileRequestStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategyTests.swift; sourceTree = "<group>"; };
 		F154EDC41F447B6C00CB8184 /* WireRequestStrategyTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WireRequestStrategyTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1587,6 +1589,7 @@
 				EEE0EE0328591D2C00BBEE29 /* OptionalString+NonEmptyValue.swift */,
 				631216382881D10100FF9A56 /* ZMUpdateEvent+Payload.swift */,
 				633B39692891890500208124 /* ZMUpdateEvent+Decryption.swift */,
+				EEE46E5328C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1939,6 +1942,7 @@
 				631216392881D10100FF9A56 /* ZMUpdateEvent+Payload.swift in Sources */,
 				1622946D221C56E500A98679 /* AssetsPreprocessor.swift in Sources */,
 				0649D1A624F673E7001DDC78 /* Logging.swift in Sources */,
+				EEE46E5428C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift in Sources */,
 				EE8DC53728C0EFA700AC4E3D /* FetchUserClientsActionHandler.swift in Sources */,
 				16229487221EBB8100A98679 /* ZMImagePreprocessingTracker.m in Sources */,
 				16E70F8E270EEBB700718E5D /* PayloadProcessing+MessageSendingStatus.swift in Sources */,

--- a/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -229,6 +229,9 @@
 		EE57BD9D28A52DD600C46660 /* MLSMessageSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57BD9C28A52DD600C46660 /* MLSMessageSyncTests.swift */; };
 		EE57BD9F28A52E3100C46660 /* MessageSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57BD9E28A52E3100C46660 /* MessageSyncTests.swift */; };
 		EE82318927D22D79008CD77B /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82318827D22D79008CD77B /* String+Random.swift */; };
+		EE8DC53528C0EF7800AC4E3D /* FetchUserClientsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DC53428C0EF7800AC4E3D /* FetchUserClientsAction.swift */; };
+		EE8DC53728C0EFA700AC4E3D /* FetchUserClientsActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DC53628C0EFA700AC4E3D /* FetchUserClientsActionHandler.swift */; };
+		EE8DC53928C0F04B00AC4E3D /* FetchUserClientsActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DC53828C0F04B00AC4E3D /* FetchUserClientsActionHandlerTests.swift */; };
 		EE90C29E282E785800474379 /* PushTokenStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE90C29D282E785800474379 /* PushTokenStrategy.swift */; };
 		EE90C2A7282E7EC800474379 /* RegisterPushTokenActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE90C2A6282E7EC800474379 /* RegisterPushTokenActionHandler.swift */; };
 		EE90C2A8282E7ECF00474379 /* RegisterPushTokenAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE90C2A4282E7EA900474379 /* RegisterPushTokenAction.swift */; };
@@ -627,6 +630,9 @@
 		EE57BD9C28A52DD600C46660 /* MLSMessageSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSMessageSyncTests.swift; sourceTree = "<group>"; };
 		EE57BD9E28A52E3100C46660 /* MessageSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSyncTests.swift; sourceTree = "<group>"; };
 		EE82318827D22D79008CD77B /* String+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		EE8DC53428C0EF7800AC4E3D /* FetchUserClientsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserClientsAction.swift; sourceTree = "<group>"; };
+		EE8DC53628C0EFA700AC4E3D /* FetchUserClientsActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserClientsActionHandler.swift; sourceTree = "<group>"; };
+		EE8DC53828C0F04B00AC4E3D /* FetchUserClientsActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserClientsActionHandlerTests.swift; sourceTree = "<group>"; };
 		EE90C29D282E785800474379 /* PushTokenStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTokenStrategy.swift; sourceTree = "<group>"; };
 		EE90C2A4282E7EA900474379 /* RegisterPushTokenAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushTokenAction.swift; sourceTree = "<group>"; };
 		EE90C2A6282E7EC800474379 /* RegisterPushTokenActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushTokenActionHandler.swift; sourceTree = "<group>"; };
@@ -1284,6 +1290,9 @@
 				F18401602073BE0800E9F4CC /* MissingClientsRequestFactory.swift */,
 				F18401612073BE0800E9F4CC /* FetchingClientRequestStrategy.swift */,
 				F184015E2073BE0800E9F4CC /* FetchingClientRequestStrategyTests.swift */,
+				EE8DC53428C0EF7800AC4E3D /* FetchUserClientsAction.swift */,
+				EE8DC53628C0EFA700AC4E3D /* FetchUserClientsActionHandler.swift */,
+				EE8DC53828C0F04B00AC4E3D /* FetchUserClientsActionHandlerTests.swift */,
 				166A22902577C06B00EF313D /* ResetSessionRequestStrategy.swift */,
 				16824632257A2B47002AF17B /* ResetSessionRequestStrategyTests.swift */,
 				1662ADB222B0E8B300D84071 /* VerifyLegalHoldRequestStrategy.swift */,
@@ -1922,6 +1931,7 @@
 				F18401D22073BE0800E9F4CC /* OTREntity.swift in Sources */,
 				16A4893A268A080E001F9127 /* InsertedObjectSync.swift in Sources */,
 				1621D22F1D75AC36007108C2 /* ZMChangeTrackerBootstrap.m in Sources */,
+				EE8DC53528C0EF7800AC4E3D /* FetchUserClientsAction.swift in Sources */,
 				062285C8276BB5B000B87C91 /* UpdateEventProcessor.swift in Sources */,
 				7A111DE8285C90A90085BF91 /* SendMLSMessageActionHandler.swift in Sources */,
 				0649D19F24F6717C001DDC78 /* ZMLocalNotificationSet.swift in Sources */,
@@ -1929,6 +1939,7 @@
 				631216392881D10100FF9A56 /* ZMUpdateEvent+Payload.swift in Sources */,
 				1622946D221C56E500A98679 /* AssetsPreprocessor.swift in Sources */,
 				0649D1A624F673E7001DDC78 /* Logging.swift in Sources */,
+				EE8DC53728C0EFA700AC4E3D /* FetchUserClientsActionHandler.swift in Sources */,
 				16229487221EBB8100A98679 /* ZMImagePreprocessingTracker.m in Sources */,
 				16E70F8E270EEBB700718E5D /* PayloadProcessing+MessageSendingStatus.swift in Sources */,
 				F18401D02073BE0800E9F4CC /* PushMessageHandler.swift in Sources */,
@@ -2007,6 +2018,7 @@
 				16972DED2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift in Sources */,
 				F19561FB202A13C3005347C0 /* ZMSyncOperationSetTests.m in Sources */,
 				F18401E92073C26700E9F4CC /* AvailabilityRequestStrategyTests.swift in Sources */,
+				EE8DC53928C0F04B00AC4E3D /* FetchUserClientsActionHandlerTests.swift in Sources */,
 				0693114D24F79A1100D14DF5 /* ZMLocalNotificationLocalizationTests.swift in Sources */,
 				EE9BC57E28785FB100AF9AEE /* XCTestCase+APIVersion.swift in Sources */,
 				EE57BD9D28A52DD600C46660 /* MLSMessageSyncTests.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-675" title="FS-675" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-675</a>  [iOS] Distribute CONFKEY to all members of conversation [temp-M4]
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Sending of calling messages happens in the sync engine. In order to send call messages in an MLS group, we need to use `MessageSync`, which is currently internal. This PR opens the access to `public`.

Additionally, we also need to determine the type of call message, particularly if it is a conference key or a reject message. This PR also adds helper methods to `CallEventContent`. 

We also add the caller client id to the `CallEventContent` because we need this to process the call in the sync engine, and this is no longer given to us in the update event containing the mls calling message.

Finally, part of the calling flow is to get the list clients in the conversation to then pass to AVS. We normally do this by sending an OTR message to no-one, getting back a 412 error response, and parsing the list of missing clients in the response. We can't do this with MLS messages, so instead we need to fetch the clients directly. To do this, I created `FetchUserClientsAction` which returns all user clients ids for a set of user ids.

### Testing

- Updated tests
- Unit tests for fetching user clients

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
