### PR TITLE
fix: Add additional properties to CallEventContent

### DIFF
--- a/Sources/Notifications/CallEventContent.swift
+++ b/Sources/Notifications/CallEventContent.swift
@@ -66,13 +66,17 @@ public struct CallEventContent: Decodable {
     }
 
     public var callState: LocalNotificationType.CallState? {
-        if isStartCall && !resp {
+        if isIncomingCall {
             return .incomingCall(video: properties?.isVideo ?? false)
         } else if isEndCall {
             return .missedCall(cancelled: true)
         } else {
             return nil
         }
+    }
+
+    public var isIncomingCall: Bool {
+        return isStartCall && !resp
     }
 
     public var isStartCall: Bool {

--- a/Sources/Notifications/CallEventContent.swift
+++ b/Sources/Notifications/CallEventContent.swift
@@ -120,6 +120,14 @@ public struct CallEventContent: Decodable {
         return type == "REMOTEMUTE"
     }
 
+    public var isVideo: Bool {
+        guard let properties = properties else {
+            return false
+        }
+
+        return properties.isVideo
+    }
+
 }
 
 extension CallEventContent {

--- a/Sources/Notifications/CallEventContent.swift
+++ b/Sources/Notifications/CallEventContent.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public struct CallEventContent: Decodable {
 
-    private enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
 
         case type
 
@@ -36,7 +36,7 @@ public struct CallEventContent: Decodable {
 
     /// Call event type.
 
-    let type: String
+    public let type: String
 
     /// Properties containing info whether the incoming call has video or not.
 
@@ -46,7 +46,7 @@ public struct CallEventContent: Decodable {
 
     let callerIdString: String
 
-    let resp: Bool
+    public let resp: Bool
 
     // MARK: - Life cycle
 
@@ -79,12 +79,20 @@ public struct CallEventContent: Decodable {
         return isStartCall && !resp
     }
 
+    public var isAnsweredElsewhere: Bool {
+        return isStartCall && resp
+    }
+
     public var isStartCall: Bool {
         return type.isOne(of: ["SETUP", "GROUPSTART", "CONFSTART"])
     }
 
     public var isEndCall: Bool {
         return type.isOne(of: ["CANCEL", "GROUPEND", "CONFEND"])
+    }
+
+    public var isRegected: Bool {
+        return type == "REJECT"
     }
 
     public var isRemoteMute: Bool {

--- a/Sources/Notifications/Push Notifications/Notification Types/Helpers/ZMLocalNotificationSet.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Helpers/ZMLocalNotificationSet.swift
@@ -140,7 +140,7 @@ extension ZMLocalNotificationSet {
     }
 }
 
-extension ZMConversation {
+public extension ZMConversation {
     func localizedCallerName(with user: ZMUser) -> String {
 
         let conversationName = self.userDefinedName

--- a/Sources/Notifications/VoIPPushHelper.swift
+++ b/Sources/Notifications/VoIPPushHelper.swift
@@ -71,17 +71,7 @@ public enum VoIPPushHelper {
         }
     }
 
-    public static func setOngoingCalls(conversationIDs: [UUID]) {
-        callKitCalls = conversationIDs.map(\.uuidString)
-    }
-
-    public static func existsOngoingCallInConversation(withID id: UUID) -> Bool {
-        return callKitCalls
-            .compactMap(UUID.init(uuidString:))
-            .contains(id)
-    }
-
-    private static var callKitCalls: [String] {
+    public static var knownCallHandles: [String] {
         get {
             storage.object(forKey: Key.knownCalls.rawValue) as? [String] ?? []
         }

--- a/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -111,6 +111,7 @@ extension EventDecoder {
     fileprivate func decryptAndStoreEvents(_ events: [ZMUpdateEvent], startingAtIndex startIndex: Int64) -> [ZMUpdateEvent] {
         let account = Account(userName: "", userIdentifier: ZMUser.selfUser(in: self.syncMOC).remoteIdentifier)
         let publicKey = try? EncryptionKeys.publicKey(for: account)
+        Logging.eventProcessing.info("public key exists? \(publicKey != nil)")
         var decryptedEvents: [ZMUpdateEvent] = []
 
         syncMOC.zm_cryptKeyStore.encryptionContext.perform { [weak self] (sessionsDirectory) -> Void in
@@ -145,6 +146,8 @@ extension EventDecoder {
     // This method terminates when no more events are in the database.
     private func process(with encryptionKeys: EncryptionKeys?, _ consumeBlock: ConsumeBlock, firstCall: Bool) {
         let events = fetchNextEventsBatch(with: encryptionKeys)
+        Logging.eventProcessing.info("encryption keys exist? \(encryptionKeys != nil)")
+        Logging.eventProcessing.info("fetched events, stored: \(events.storedEvents.count), update: \(events.updateEvents.count)")
         guard events.storedEvents.count > 0 else {
             if firstCall {
                 consumeBlock([])

--- a/Sources/Synchronization/Decoding/StoreUpdateEvent.swift
+++ b/Sources/Synchronization/Decoding/StoreUpdateEvent.swift
@@ -125,8 +125,11 @@ public final class StoredUpdateEvent: NSManagedObject {
     /// - Returns: a dictionary which contains decrypted payload
     private static func decryptPayloadIfNeeded(storedEvent: StoredUpdateEvent, encryptionKeys: EncryptionKeys?) -> NSDictionary? {
         if !storedEvent.isEncrypted {
+            Logging.eventProcessing.info("stored event is not encrypted")
             return storedEvent.payload
         }
+
+        Logging.eventProcessing.info("stored event is encrypted")
 
         guard let keys = encryptionKeys,
             let encryptedPayload = storedEvent.payload?[encryptedPayloadKey] as? Data,
@@ -134,6 +137,7 @@ public final class StoredUpdateEvent: NSManagedObject {
                                                           .eciesEncryptionCofactorX963SHA256AESGCM,
                                                           encryptedPayload as CFData,
                                                           nil) else {
+                Logging.eventProcessing.info("couldn't decrypt")
                                                             return nil
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add `isIncomingCall`, `isAnsweredElsewhere`, `isRegected` properties to `CallEventContent`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
