### PR TITLE
feat: Add isVideo property to the CallEventContent

### DIFF
--- a/Sources/Notifications/CallEventContent.swift
+++ b/Sources/Notifications/CallEventContent.swift
@@ -120,6 +120,14 @@ public struct CallEventContent: Decodable {
         return type == "REMOTEMUTE"
     }
 
+    public var isVideo: Bool {
+        guard let properties = properties else {
+            return false
+        }
+
+        return properties.isVideo
+    }
+
 }
 
 extension CallEventContent {

--- a/Sources/Notifications/Push Notifications/Notification Types/Helpers/ZMLocalNotificationSet.swift
+++ b/Sources/Notifications/Push Notifications/Notification Types/Helpers/ZMLocalNotificationSet.swift
@@ -140,7 +140,7 @@ extension ZMLocalNotificationSet {
     }
 }
 
-extension ZMConversation {
+public extension ZMConversation {
     func localizedCallerName(with user: ZMUser) -> String {
 
         let conversationName = self.userDefinedName


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add `isVideo` property to the CallEventContent.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
